### PR TITLE
Add RTP & Librarian tables

### DIFF
--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -62,7 +62,7 @@ Primary keys are bold, foreign keys are italicized.
 \subsection{Observations}
 \textbf{\large{hera\_obs}}: This is the primary observation definition table.
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
  \hline
  column & type & description \\ [0.5ex]  \hline\hline
  \textbf{obsid} & long integer & start time in floor(GPS) seconds. GPS start adjusted to be within 1 second of LST to lock observations to LST for the night \\ \hline
@@ -75,21 +75,21 @@ Primary keys are bold, foreign keys are italicized.
 \subsection{Common tables}
 \textbf{\large{server\_status}}: Common table structure for server status info. Same columns to be used in subsystem-specific instances of this table.
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
- \textbf{hostname} & string &  \\ \hline
- \textbf{timestamp} & datetime & defined by \mc \\ \hline
- ip\_address & string & host IP (how should we handle multiples?) \\\hline
-system\_time & datetime & on server \\\hline
-num\_cores & integer & Number of cores  \\\hline
-cpu\_load & float & percentage: defined by total load/\# cores, 5min average  \\\hline
-uptime & float &  \\\hline
-memory\_used & float & percent used, 5min average  \\\hline
-memory\_size & float & \\\hline
-disk\_space & float & percent used  \\\hline
-disk\_size & float &  \\\hline
-network\_bandwidth & float & fractional? can be null \\\hline
+ \textbf{hostname} & string &  name of server \\ \hline
+ \textbf{mc\_time} & float & time report received by \mc in gps seconds \\ \hline
+ ip\_address & string & IP address of server (how should we handle multiples?) \\\hline
+system\_time & float & time report sent by server in gps seconds \\\hline
+num\_cores & integer & number of cores on server \\\hline
+cpu\_load\_pct & float & CPU load percent = total load / num\_cores, 5 min average  \\\hline
+uptime\_days & float & server uptime in days  \\\hline
+memory\_used\_pct & float & percent of memory used, 5 min average  \\\hline
+memory\_size\_gb & float & amount of memory on server in GB \\\hline
+disk\_space\_pct & float & percent of disk used  \\\hline
+disk\_size\_gb & float & amount of disk space on server in GB \\\hline
+network\_bandwidth\_mps & float & Network bandwidth in MB/s, 5 min average. Can be null \\\hline
 \end{tabular}
 \end{center}
 
@@ -98,11 +98,11 @@ network\_bandwidth & float & fractional? can be null \\\hline
 
 \textbf{\large{rtp\_status}}: High level RTP status
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-status & string & TBD  \\\hline
+\textbf{time} & float & status time in gps seconds\\ \hline
+status & string & status string, options TBD (might become an enum) \\\hline
 event\_min\_elapsed & float & minutes elapsed since last event \\\hline
 num\_processes & integer & Number of processes running  \\\hline
 restart\_hours\_elapsed & float & hours elapsed since last restart \\\hline
@@ -111,24 +111,24 @@ restart\_hours\_elapsed & float & hours elapsed since last restart \\\hline
 
 \textbf{\large{rtp\_process\_events}}: RTP Processing events (per obsid)
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-\textit{\textbf{obsid}} & long integer & \\ \hline
+\textbf{time} & float & event time in gps seconds \\ \hline
+\textit{\textbf{obsid}} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
 event & string & one of: queued, started, finished, error  \\\hline
 \end{tabular}
 \end{center}
 
 \textbf{\large{rtp\_process\_record}}: RTP record of processed obsids (entry added when processing finished)
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-\textit{\textbf{obsid}} & long integer & \\ \hline
-pipeline\_list & string & concatenated list of tasks  \\\hline
-git\_version & string & version of RTP code  \\\hline
+\textbf{time} & float & record time in gps seconds\\ \hline
+\textit{\textbf{obsid}} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
+pipeline\_list & text & concatenated list of tasks  \\\hline
+git\_version & string & git version of RTP code  \\\hline
 git\_hash & string & git hash of RTP code  \\\hline
 \end{tabular}
 \end{center}
@@ -139,66 +139,66 @@ git\_hash & string & git hash of RTP code  \\\hline
 
 \textbf{\large{lib\_status}}: High level Librarian status
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-num\_files & long & total number of files  \\\hline
+\textbf{time} & float & status time in gps seconds \\ \hline
+num\_files & long & total number of files in librarian  \\\hline
 data\_volume\_gb & float & total data volume in gigabytes  \\\hline
 free\_space\_gb & float & available space in gigabytes  \\\hline
 upload\_min\_elapsed & float & minutes elapsed since last file upload \\\hline
-num\_processes & integer & Number of running background tasks  \\\hline
-git\_version & string & version of Librarian code  \\\hline
+num\_processes & integer & number of running background tasks  \\\hline
+git\_version & string & git version of Librarian code  \\\hline
 git\_hash & string & git hash of Librarian code  \\\hline
 \end{tabular}
 \end{center}
 
 \textbf{\large{lib\_raid\_status}}: RAID controller status
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-\textbf{hostname} & string & \\ \hline
-num\_disks & int & number of disks  \\\hline
-Info & string & TBD -- various info from megaraid controller, may be several columns \\\hline
+\textbf{time} & float & status time in gps seconds \\ \hline
+\textbf{hostname} & string & name of RAID server \\ \hline
+num\_disks & int & number of disks in RAID server  \\\hline
+info & text & TBD -- various info from megaraid controller, may be several columns \\\hline
 \end{tabular}
 \end{center}
 
 \textbf{\large{lib\_raid\_errors}}: RAID controller errors/issues
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-\textbf{hostname} & string & \\ \hline
-\textbf{disk} & string or int? &  \\ \hline
-log or file & string & TBD on format, either a message or a file with the log \\\hline
+\textbf{time} & float & error report time in gps seconds\\ \hline
+\textbf{hostname} & string & name of RAID server with error \\ \hline
+\textbf{disk} & string & name of disk with error \\ \hline
+log & text & TBD on format, either a message or a file with the log \\\hline
 \end{tabular}
 \end{center}
 
-\textbf{\large{lib\_remote\_bandwidth}}: Network bandwidth/health to all remote librarians
+\textbf{\large{lib\_remote\_status}}: Network bandwidth/health to all remote librarians
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & datetime & \\ \hline
-\textbf{remote\_name} & string & \\ \hline
-ping\_time & float & ping time in seconds (?) \\\hline
-num\_recent\_files & int & number of files uploaded in last 15 minutes  \\\hline
-bandwidth & float & Mb/s average over 15 minutes \\\hline
+\textbf{time} & float & status time in gps seconds\\ \hline
+\textbf{remote\_name} & string & name of remote librarian \\ \hline
+ping\_time & float & ping time in seconds \\\hline
+num\_file\_uploads & int & number of files uploaded in last 15 minutes  \\\hline
+bandwidth\_mps & float & bandwidth to remote in Mb/s, 15 minute average \\\hline
 \end{tabular}
 \end{center}
 
-\textbf{\large{lib\_file\_log}}: File creation log
+\textbf{\large{lib\_files}}: File creation log
 \begin{center}
- \begin{tabular}{| p{3cm} | p{2cm} | p{10cm} |} 
+ \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{filename} & string & \\ \hline
-\textit{obsid} & long integer & \\ \hline
-time & datetime & \\ \hline
-size & float & in gigabytes? \\ \hline
+\textbf{filename} & string & name of file created \\ \hline
+\textit{obsid} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
+time & float & file creation time in gps seconds\\ \hline
+size\_gb & float & file size in gigabytes \\ \hline
 \end{tabular}
 \end{center}
 

--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -144,9 +144,9 @@ git\_hash & string & git hash of RTP code  \\\hline
  column & type & description \\ [0.5ex]  \hline\hline
 \textbf{time} & datetime & \\ \hline
 num\_files & long & total number of files  \\\hline
-data\_volume & float & total data volume (in gigabytes?)  \\\hline
-free\_space & float & available space (in gigabytes?)  \\\hline
-t\_since\_upload & float & time elapsed since last file upload (in seconds? or minutes?) \\\hline
+data\_volume\_gb & float & total data volume in gigabytes  \\\hline
+free\_space\_gb & float & available space in gigabytes  \\\hline
+upload\_min\_elapsed & float & minutes elapsed since last file upload \\\hline
 num\_processes & integer & Number of running background tasks  \\\hline
 git\_version & string & version of Librarian code  \\\hline
 git\_hash & string & git hash of Librarian code  \\\hline
@@ -196,7 +196,7 @@ bandwidth & float & Mb/s average over 15 minutes \\\hline
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
 \textbf{filename} & string & \\ \hline
-\textit{obside} & long integer & \\ \hline
+\textit{obsid} & long integer & \\ \hline
 time & datetime & \\ \hline
 size & float & in gigabytes? \\ \hline
 \end{tabular}

--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -103,9 +103,9 @@ network\_bandwidth & float & fractional? can be null \\\hline
  column & type & description \\ [0.5ex]  \hline\hline
 \textbf{time} & datetime & \\ \hline
 status & string & TBD  \\\hline
-t\_since\_event & float & time elapsed since last event (in seconds? or minutes?) \\\hline
+event\_min\_elapsed & float & minutes elapsed since last event \\\hline
 num\_processes & integer & Number of processes running  \\\hline
-t\_since\_restart & float & time since last restart (in minutes? hours?) \\\hline
+restart\_hours\_elapsed & float & hours elapsed since last restart \\\hline
 \end{tabular}
 \end{center}
 

--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -80,9 +80,9 @@ Primary keys are bold, foreign keys are italicized.
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
  \textbf{hostname} & string &  name of server \\ \hline
- \textbf{mc\_time} & float & time report received by \mc in gps seconds \\ \hline
+ \textbf{mc\_time} & long & time report received by \mc\ in floor(gps seconds) \\ \hline
  ip\_address & string & IP address of server (how should we handle multiples?) \\\hline
-system\_time & float & time report sent by server in gps seconds \\\hline
+mc\_system\_timediff & float & difference between \mc\ time and time report sent by server in seconds \\\hline
 num\_cores & integer & number of cores on server \\\hline
 cpu\_load\_pct & float & CPU load percent = total load / num\_cores, 5 min average  \\\hline
 uptime\_days & float & server uptime in days  \\\hline
@@ -102,7 +102,7 @@ network\_bandwidth\_mps & float & Network bandwidth in MB/s, 5 min average. Can 
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & status time in gps seconds\\ \hline
+\textbf{time} & long & status time in floor(gps seconds)\\ \hline
 status & string & status string, options TBD (might become an enum) \\\hline
 event\_min\_elapsed & float & minutes elapsed since last event \\\hline
 num\_processes & integer & Number of processes running  \\\hline
@@ -115,7 +115,7 @@ restart\_hours\_elapsed & float & hours elapsed since last restart \\\hline
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & event time in gps seconds \\ \hline
+\textbf{time} & long & event time in floor(gps seconds) \\ \hline
 \textit{\textbf{obsid}} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
 event & string & one of: queued, started, finished, error  \\\hline
 \end{tabular}
@@ -126,7 +126,7 @@ event & string & one of: queued, started, finished, error  \\\hline
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & record time in gps seconds\\ \hline
+\textbf{time} & long & record time in floor(gps seconds)\\ \hline
 \textit{\textbf{obsid}} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
 pipeline\_list & text & concatenated list of tasks  \\\hline
 git\_version & string & git version of RTP code  \\\hline
@@ -143,7 +143,7 @@ git\_hash & string & git hash of RTP code  \\\hline
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & status time in gps seconds \\ \hline
+\textbf{time} & long & status time in floor(gps seconds) \\ \hline
 num\_files & long & total number of files in librarian  \\\hline
 data\_volume\_gb & float & total data volume in gigabytes  \\\hline
 free\_space\_gb & float & available space in gigabytes  \\\hline
@@ -159,7 +159,7 @@ git\_hash & string & git hash of Librarian code  \\\hline
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & status time in gps seconds \\ \hline
+\textbf{time} & long & status time in floor(gps seconds) \\ \hline
 \textbf{hostname} & string & name of RAID server \\ \hline
 num\_disks & int & number of disks in RAID server  \\\hline
 info & text & TBD -- various info from megaraid controller, may be several columns \\\hline
@@ -171,7 +171,7 @@ info & text & TBD -- various info from megaraid controller, may be several colum
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & error report time in gps seconds\\ \hline
+\textbf{time} & long & error report time in floor(gps seconds)\\ \hline
 \textbf{hostname} & string & name of RAID server with error \\ \hline
 \textbf{disk} & string & name of disk with error \\ \hline
 log & text & TBD on format, either a message or a file with the log \\\hline
@@ -183,7 +183,7 @@ log & text & TBD on format, either a message or a file with the log \\\hline
  \begin{tabular}{| p{4cm} | p{2cm} | p{10cm} |} 
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
-\textbf{time} & float & status time in gps seconds\\ \hline
+\textbf{time} & long & status time in floor(gps seconds)\\ \hline
 \textbf{remote\_name} & string & name of remote librarian \\ \hline
 ping\_time & float & ping time in seconds \\\hline
 num\_file\_uploads & int & number of files uploaded in last 15 minutes  \\\hline
@@ -198,7 +198,7 @@ bandwidth\_mps & float & bandwidth to remote in Mb/s, 15 minute average \\\hline
  column & type & description \\ [0.5ex]  \hline\hline
 \textbf{filename} & string & name of file created \\ \hline
 \textit{obsid} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
-time & float & file creation time in gps seconds\\ \hline
+time & long & file creation time in floor(gps seconds)\\ \hline
 size\_gb & float & file size in gigabytes \\ \hline
 \end{tabular}
 \end{center}

--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -66,9 +66,10 @@ Primary keys are bold, foreign keys are italicized.
  \hline
  column & type & description \\ [0.5ex]  \hline\hline
  \textbf{obsid} & long integer & start time in floor(GPS) seconds. GPS start adjusted to be within 1 second of LST to lock observations to LST for the night \\ \hline
- start\_time\_jd & double & start time in decimal JD. The start time to full accuracy of the beginning of integration of first visibility \\\hline
- stop\_time\_jd & double & stop time in decimal JD. The stop time to full accuracy of the end of integration of last visibility \\\hline
- lst\_start\_hr & double & decimal hours from start of sidereal day. Provides a quick search for overlapping LSTs \\\hline
+ starttime & double & start time in gps seconds. The start time to full accuracy of the beginning of integration of first visibility \\\hline
+ stoptime & double & stop time in gps seconds. The stop time to full accuracy of the end of integration of last visibility \\\hline
+ jd\_start & double & start time in JD. Calculated from starttime, provides a quick way to filter on JD times. \\\hline
+ lst\_start\_hr & double & decimal hours from start of sidereal day. Calculated from starttime, provides a quick search for matching LSTs \\\hline
  \end{tabular}
 \end{center}
 

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.declarative import declarative_base
 MCDeclarativeBase = declarative_base()
 
 
-def __repr__(self):
+def MCDeclarativeBase_repr(self):
     columns = self.__table__.columns.keys()
     rep_str = '<' + self.__class__.__name__ + '('
     for c in columns:
@@ -22,42 +22,45 @@ def __repr__(self):
     rep_str += ')>'
     return rep_str
 
+# define some default tolerances for various units
+DEFAULT_DAY_TOL = {'atol': 1e-3 / (3600. * 24.), 'rtol': 0} # ms
+DEFAULT_HOUR_TOL = {'atol': 1e-3 / (3600), 'rtol': 0} # ms
+DEFAULT_MIN_TOL = {'atol': 1e-3 / (3600), 'rtol': 0} # ms
+DEFAULT_GPS_TOL = {'atol': 1e-3, 'rtol': 0} # ms
 
-def __eq__(self, other):
-    if isinstance(other, self.__class__):
-
-        self_columns = self.__table__.columns
-        other_columns = other.__table__.columns
-        if set(c.name for c in self_columns) != set(c.name for c in other_columns):
-            return False
-
-        c_equal = True
-        for c in self_columns:
-            self_c = getattr(self, c.name)
-            other_c = getattr(other, c.name)
-            if isinstance(self_c, (str, unicode, int, long)):
-                if self_c != other_c:
-                    c_equal = False
-            elif isinstance(self_c, (np.ndarray)) and isinstance(self_c.dtype, (int, long)):
-                if not np.all(self_c == other_c):
-                    c_equal = False
-            else:
-                if hasattr(self, 'tols') and c.name in self.tols.keys():
-                    atol = self.tols[c.name]['atol']
-                    rtol = self.tols[c.name]['rtol']
-                else:
-                    # use numpy defaults
-                    atol = 1e-08
-                    rtol = 1e-05
-                if not np.isclose(self_c, other_c, atol=atol, rtol=rtol):
-                    c_equal = False
-        return c_equal
-    else:
+def MCDeclarativeBase_eq(self, other):
+    if not isinstance(other, self.__class__):
         return False
 
+    self_columns = self.__table__.columns
+    other_columns = other.__table__.columns
+    if set(c.name for c in self_columns) != set(c.name for c in other_columns):
+        return False
 
-MCDeclarativeBase.__repr__ = MethodType(__repr__, None, MCDeclarativeBase)
-MCDeclarativeBase.__eq__ = MethodType(__eq__, None, MCDeclarativeBase)
+    for c in self_columns:
+        self_c = getattr(self, c.name)
+        other_c = getattr(other, c.name)
+        if isinstance(self_c, (str, unicode, int, long)):
+            if self_c != other_c:
+                return False
+        elif isinstance(self_c, (np.ndarray)) and isinstance(self_c.dtype, (int, long)):
+            if not np.all(self_c == other_c):
+                return False
+        else:
+            if hasattr(self, 'tols') and c.name in self.tols.keys():
+                atol = self.tols[c.name]['atol']
+                rtol = self.tols[c.name]['rtol']
+            else:
+                # use numpy defaults
+                atol = 1e-08
+                rtol = 1e-05
+            if not np.isclose(self_c, other_c, atol=atol, rtol=rtol):
+                return False
+    return True
+
+
+MCDeclarativeBase.__repr__ = MethodType(MCDeclarativeBase_repr, None, MCDeclarativeBase)
+MCDeclarativeBase.__eq__ = MethodType(MCDeclarativeBase_eq, None, MCDeclarativeBase)
 
 
 import logging

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -40,7 +40,6 @@ def __eq__(self, other):
         for c in self_columns:
             self_c = getattr(self, c)
             other_c = getattr(other, c)
-            print('column ', c, ', type is ', type(self_c))
             if isinstance(self_c, (str, unicode)):
                 if self_c != other_c:
                     print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -22,13 +22,15 @@ def MCDeclarativeBase_repr(self):
     rep_str += ')>'
     return rep_str
 
-# define some default tolerances for various units
-DEFAULT_DAY_TOL = {'atol': 1e-3 / (3600. * 24.), 'rtol': 0} # ms
-DEFAULT_HOUR_TOL = {'atol': 1e-3 / (3600), 'rtol': 0} # ms
-DEFAULT_MIN_TOL = {'atol': 1e-3 / (3600), 'rtol': 0} # ms
-DEFAULT_GPS_TOL = {'atol': 1e-3, 'rtol': 0} # ms
 
-def MCDeclarativeBase_eq(self, other):
+# define some default tolerances for various units
+DEFAULT_DAY_TOL = {'atol': 1e-3 / (3600. * 24.), 'rtol': 0}  # ms
+DEFAULT_HOUR_TOL = {'atol': 1e-3 / (3600), 'rtol': 0}  # ms
+DEFAULT_MIN_TOL = {'atol': 1e-3 / (3600), 'rtol': 0}  # ms
+DEFAULT_GPS_TOL = {'atol': 1e-3, 'rtol': 0}  # ms
+
+
+def MCDeclarativeBase_close(self, other):
     if not isinstance(other, self.__class__):
         return False
 
@@ -60,8 +62,7 @@ def MCDeclarativeBase_eq(self, other):
 
 
 MCDeclarativeBase.__repr__ = MethodType(MCDeclarativeBase_repr, None, MCDeclarativeBase)
-MCDeclarativeBase.__eq__ = MethodType(MCDeclarativeBase_eq, None, MCDeclarativeBase)
-
+MCDeclarativeBase.isclose = MethodType(MCDeclarativeBase_close, None, MCDeclarativeBase)
 
 import logging
 logger = logging.getLogger(__name__)

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -80,6 +80,6 @@ from . import part_connect
 from . import geo_location
 from . import temperatures
 from . import observations
-from . import server_status
+from . import server_status  # remove this later so this table isn't made?
 from . import rtp
 from . import mc  # keep this last.

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -74,6 +74,7 @@ from . import part_connect
 from . import geo_location
 from . import temperatures
 from . import observations
-from . import server_status  # remove this later so this table isn't made?
+from . import server_status
+from . import librarian
 from . import rtp
 from . import mc  # keep this last.

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -3,12 +3,67 @@
 # Licensed under the 2-clause BSD license.
 
 from __future__ import absolute_import, division, print_function
+from types import MethodType
+import datetime
+import pytz
+import numpy as np
 
 # Before we can do anything else, we need to initialize some core, shared
 # variables.
 
 from sqlalchemy.ext.declarative import declarative_base
 MCDeclarativeBase = declarative_base()
+
+
+def __repr__(self):
+    columns = self.__table__.columns.keys()
+    rep_str = '<' + self.__class__.__name__ + '('
+    for c in columns:
+        rep_str += str(getattr(self, c)) + ', '
+    rep_str = rep_str[0:-2]
+    rep_str += ')>'
+    return rep_str
+
+
+def __eq__(self, other):
+    if isinstance(other, self.__class__):
+
+        self_columns = self.__table__.columns.keys()
+        other_columns = other.__table__.columns.keys()
+        if set(self_columns) != set(other_columns):
+            print('Sets of columns do not match. Left is {lset},'
+                  ' right is {rset}'.format(lset=self_columns,
+                                            rset=other_columns))
+            return False
+
+        c_equal = True
+        for c in self_columns:
+            self_c = getattr(self, c)
+            other_c = getattr(other, c)
+            print('column ', c, ', type is ', type(self_c))
+            if isinstance(self_c, (str, unicode)):
+                if self_c != other_c:
+                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
+                    c_equal = False
+            elif isinstance(self_c, datetime.datetime):
+                self_c = self_c.astimezone(pytz.utc)
+                other_c = other_c.astimezone(pytz.utc)
+                if self_c != other_c:
+                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
+                    c_equal = False
+            else:
+                if not np.isclose(self_c, other_c):
+                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
+                    c_equal = False
+        return c_equal
+    else:
+        print('Classes do not match')
+        return False
+
+
+MCDeclarativeBase.__repr__ = MethodType(__repr__, None, MCDeclarativeBase)
+MCDeclarativeBase.__eq__ = MethodType(__eq__, None, MCDeclarativeBase)
+
 
 import logging
 logger = logging.getLogger(__name__)

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -29,9 +29,6 @@ def __eq__(self, other):
         self_columns = self.__table__.columns
         other_columns = other.__table__.columns
         if set(c.name for c in self_columns) != set(c.name for c in other_columns):
-            print('Sets of columns do not match. Left is {lset},'
-                  ' right is {rset}'.format(lset=self_columns,
-                                            rset=other_columns))
             return False
 
         c_equal = True
@@ -40,7 +37,6 @@ def __eq__(self, other):
             other_c = getattr(other, c.name)
             if isinstance(self_c, (str, unicode)):
                 if self_c != other_c:
-                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
                     c_equal = False
             else:
                 if hasattr(self, 'tols') and c.name in self.tols.keys():
@@ -51,11 +47,9 @@ def __eq__(self, other):
                     atol = 1e-08
                     rtol = 1e-05
                 if not np.isclose(self_c, other_c, atol=atol, rtol=rtol):
-                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
                     c_equal = False
         return c_equal
     else:
-        print('Classes do not match')
         return False
 
 

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -82,4 +82,5 @@ from . import geo_location
 from . import temperatures
 from . import observations
 from . import server_status
+from . import rtp
 from . import mc  # keep this last.

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -35,8 +35,11 @@ def __eq__(self, other):
         for c in self_columns:
             self_c = getattr(self, c.name)
             other_c = getattr(other, c.name)
-            if isinstance(self_c, (str, unicode)):
+            if isinstance(self_c, (str, unicode, int, long)):
                 if self_c != other_c:
+                    c_equal = False
+            elif isinstance(self_c, (np.ndarray)) and isinstance(self_c.dtype, (int, long)):
+                if not np.all(self_c == other_c):
                     c_equal = False
             else:
                 if hasattr(self, 'tols') and c.name in self.tols.keys():

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -26,4 +26,6 @@ from . import host_status
 from . import part_connect
 from . import geo_location
 from . import temperatures
+from . import observations
+from . import server_status
 from . import mc  # keep this last.

--- a/hera_mc/librarian.py
+++ b/hera_mc/librarian.py
@@ -8,6 +8,11 @@
 from astropy.time import Time
 from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float
 from . import MCDeclarativeBase
+from .server_status import ServerStatus
+
+
+class LibServerStatus(ServerStatus):
+    __tablename__ = 'lib_server_status'
 
 
 class LibStatus(MCDeclarativeBase):

--- a/hera_mc/librarian.py
+++ b/hera_mc/librarian.py
@@ -1,13 +1,16 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2016 the HERA Collaboration
+# Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
-"""Librarian tables
+"""
+Librarian tables
 
+The columns in this module are documented in docs/mc_definition.tex,
+the documentation needs to be kept up to date with any changes.
 """
 from astropy.time import Time
 from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float
-from . import MCDeclarativeBase
+from . import MCDeclarativeBase, DEFAULT_GPS_TOL, DEFAULT_MIN_TOL
 from .server_status import ServerStatus
 
 
@@ -38,14 +41,14 @@ class LibStatus(MCDeclarativeBase):
     git_version = Column(String(32), nullable=False)
     git_hash = Column(String(64), nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0},
+    tols = {'time': DEFAULT_GPS_TOL,
             'data_volume_gb': {'atol': 1e-3, 'rtol': 0},
             'free_space_gb': {'atol': 1e-3, 'rtol': 0},
-            'upload_min_elapsed': {'atol': 1e-3 * 60, 'rtol': 0}}
+            'upload_min_elapsed': DEFAULT_MIN_TOL}
 
     @classmethod
-    def new_status(cls, time, num_files, data_volume_gb, free_space_gb,
-                   upload_min_elapsed, num_processes, git_version, git_hash):
+    def create(cls, time, num_files, data_volume_gb, free_space_gb,
+               upload_min_elapsed, num_processes, git_version, git_hash):
         """
         Create a new lib_status object.
 
@@ -70,7 +73,7 @@ class LibStatus(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, num_files=num_files, data_volume_gb=data_volume_gb,
                    free_space_gb=free_space_gb, upload_min_elapsed=upload_min_elapsed,
@@ -93,10 +96,10 @@ class LibRAIDStatus(MCDeclarativeBase):
     num_disks = Column(Integer, nullable=False)
     info = Column(Text, nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_raid_status(cls, time, hostname, num_disks, info):
+    def create(cls, time, hostname, num_disks, info):
         """
         Create a new lib_raid_status object.
 
@@ -113,7 +116,7 @@ class LibRAIDStatus(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, hostname=hostname, num_disks=num_disks, info=info)
 
@@ -133,10 +136,10 @@ class LibRAIDErrors(MCDeclarativeBase):
     disk = Column(String, primary_key=True)
     log = Column(Text, nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_raid_error(cls, time, hostname, disk, log):
+    def create(cls, time, hostname, disk, log):
         """
         Create a new lib_raid_error object.
 
@@ -153,7 +156,7 @@ class LibRAIDErrors(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, hostname=hostname, disk=disk, log=log)
 
@@ -175,10 +178,10 @@ class LibRemoteStatus(MCDeclarativeBase):
     num_file_uploads = Column(Integer, nullable=False)
     bandwidth_mbs = Column(Float, nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_remote_status(cls, time, remote_name, ping_time, num_file_uploads, bandwidth_mbs):
+    def create(cls, time, remote_name, ping_time, num_file_uploads, bandwidth_mbs):
         """
         Create a new lib_remote_status object.
 
@@ -197,7 +200,7 @@ class LibRemoteStatus(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, remote_name=remote_name, ping_time=ping_time,
                    num_file_uploads=num_file_uploads, bandwidth_mbs=bandwidth_mbs)
@@ -218,11 +221,10 @@ class LibFiles(MCDeclarativeBase):
     time = Column(Float, nullable=False)
     size_gb = Column(Float, nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0},
-            'obsid': {'atol': 0.1, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_lib_file(cls, filename, obsid, time, size_gb):
+    def create(cls, filename, obsid, time, size_gb):
         """
         Create a new lib_file object.
 
@@ -239,6 +241,6 @@ class LibFiles(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(filename=filename, obsid=obsid, time=time, size_gb=size_gb)

--- a/hera_mc/librarian.py
+++ b/hera_mc/librarian.py
@@ -1,0 +1,73 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Librarian tables
+
+"""
+from astropy.time import Time
+from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float
+from . import MCDeclarativeBase
+
+
+class LibStatus(MCDeclarativeBase):
+    """
+    Definition of lib_status table.
+
+    time: time of this status in gps seconds (double). Primary_key
+    num_files: number of files in librarian (BigInteger)
+    data_volume_gb: data volume in GB (Float)
+    free_space_gb: free space in GB (Float)
+    upload_min_elapsed: minutes elapsed since last file upload (Float)
+    num_processes: number of background tasks running (Integer)
+    git_version: librarian git version (String)
+    git_hash: librarian git hash (String)
+    """
+    __tablename__ = 'lib_status'
+    time = Column(Float, primary_key=True)
+    num_files = Column(Integer, nullable=False)
+    data_volume_gb = Column(Float, nullable=False)
+    free_space_gb = Column(Float, nullable=False)
+    upload_min_elapsed = Column(Float, nullable=False)
+    num_processes = Column(Integer, nullable=False)
+    git_version = Column(String(32), nullable=False)
+    git_hash = Column(String(64), nullable=False)
+
+    tols = {'time': {'atol': 1e-3, 'rtol': 0},
+            'data_volume_gb': {'atol': 1e-3, 'rtol': 0},
+            'free_space_gb': {'atol': 1e-3, 'rtol': 0},
+            'upload_min_elapsed': {'atol': 1e-3 * 60, 'rtol': 0}}
+
+    @classmethod
+    def new_status(cls, time, num_files, data_volume_gb, free_space_gb,
+                   upload_min_elapsed, num_processes, git_version, git_hash):
+        """
+        Create a new lib_status object.
+
+        Parameters:
+        ------------
+        time: astropy time object
+            time of this status
+        num_files: integer
+            number of files in librarian
+        data_volume_gb: float
+            data volume in GB
+        free_space_gb: float
+            free space in GB
+        upload_min_elapsed: float
+            minutes since last file upload
+        num_processes: integer
+            number of background tasks running
+        git_version: string
+            Librarian git version
+        git_hash: string
+            Librarian git hash
+        """
+        if not isinstance(time, Time):
+            raise ValueError('time must be an astropy Time object')
+        time = time.utc.gps
+
+        return cls(time=time, num_files=num_files, data_volume_gb=data_volume_gb,
+                   free_space_gb=free_space_gb, upload_min_elapsed=upload_min_elapsed,
+                   num_processes=num_processes, git_version=git_version,
+                   git_hash=git_hash)

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -155,6 +155,64 @@ class MCSession(Session):
 
         return status_list
 
+    def add_rtp_status(self, time, status, event_min_elapsed, num_processes,
+                       restart_hours_elapsed):
+        """
+        Add a new rtp_status object.
+
+        Parameters:
+        ------------
+        time: datetime
+            time of this status
+        status: string
+            status (options TBD)
+        event_min_elapsed: float
+            minutes since last event
+        num_processes: integer
+            number of processes running
+        restart_hours_elapsed: float
+            hours since last restart
+        """
+        from .rtp import RTPStatus
+
+        self.add(RTPStatus.new_status(time, status, event_min_elapsed, num_processes,
+                                      restart_hours_elapsed))
+
+    def get_rtp_status(self, starttime, stoptime=None):
+        """
+        Get server_status record(s) from the M&C database.
+
+        Parameters:
+        ------------
+        starttime: datetime
+            time to look for records after
+
+        stoptime: datetime
+            last time to get records for. If none, only the first record after starttime will be returned.
+
+        Returns:
+        --------
+        list of RTPStatus objects
+        """
+        from .rtp import RTPStatus
+
+        if not isinstance(starttime, datetime.datetime):
+            raise ValueError('unrecognized "starttime" value: %r' % (starttime,))
+
+        if stoptime is not None:
+            if not isinstance(stoptime, datetime.datetime):
+                raise ValueError('unrecognized "stoptime" value: %r' % (stoptime,))
+
+        if stoptime is not None:
+            status_list = self.query(RTPStatus).filter(
+                RTPStatus.time.between(starttime, stoptime)).all()
+        else:
+            status_list = self.query(RTPStatus).filter(
+                RTPStatus.time >= starttime).order_by(
+                    RTPStatus.time).limit(1).all()
+
+        return status_list
+
     def add_paper_temps(self, read_time, temp_list):
         """
         Add a new PaperTemperatures record to the M&C database.

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -669,7 +669,7 @@ class MCSession(Session):
         """
         from .temperatures import PaperTemperatures
 
-        ptemp_list = self._time_filter(PaperTemperatures, 'gps_time', starttime,
+        ptemp_list = self._time_filter(PaperTemperatures, 'time', starttime,
                                        stoptime=stoptime)
 
         return ptemp_list

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -102,7 +102,7 @@ class MCSession(Session):
 
         self.add(Observation.create(starttime, stoptime, obsid))
 
-    def get_obs(self, obsid=None, starttime=None, stoptime=None):
+    def get_obs(self, obsid=None):
         """
         Get observation(s) from the M&C database.
 
@@ -110,16 +110,8 @@ class MCSession(Session):
         ------------
         obsid: long integer
             observation identification number, generally the gps second
-            corresponding to the observation start time. If not set, starttime
-            and stoptime will be used. If starttime is also none, all obsids will be returned.
-
-        starttime: astropy time object
-            time to look for records after
-
-        stoptime: astropy time object
-            last time to get records for. If none, only the first record after
-            starttime will be returned.
-
+            corresponding to the observation start time. If not obsid is None,
+            all obsids will be returned.
 
         Returns:
         --------
@@ -127,15 +119,34 @@ class MCSession(Session):
         """
         from .observations import Observation
 
-        if obsid is not None:
-            obs_list = self.query(Observation).filter(
-                Observation.obsid == obsid).all()
+        if obsid is None:
+            obs_list = self.query(Observation).all()
         else:
-            if starttime is not None:
-                obs_list = self._time_filter(Observation, 'obsid', starttime,
-                                             stoptime=stoptime)
-            else:
-                obs_list = self.query(Observation).all()
+            obs_list = self.query(Observation).filter(Observation.obsid == obsid).all()
+
+        return obs_list
+
+    def get_obs_by_time(self, starttime, stoptime=None):
+        """
+        Get observation(s) from the M&C database.
+
+        Parameters:
+        ------------
+        starttime: astropy time object
+            time to look for records after
+
+        stoptime: astropy time object
+            last time to get records for. If none, only the first record after
+            starttime will be returned.
+
+        Returns:
+        --------
+        list of Observation objects
+        """
+        from .observations import Observation
+
+        obs_list = self._time_filter(Observation, 'obsid', starttime,
+                                     stoptime=stoptime)
 
         return obs_list
 

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -120,14 +120,16 @@ class MCSession(Session):
 
         return obs_list
 
-    def add_server_status(self, hostname, ip_address, system_time, num_cores,
+    def add_server_status(self, subsystem, hostname, ip_address, system_time, num_cores,
                           cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
                           disk_space_pct, disk_size_gb, network_bandwidth_mbs=None):
         """
-        Add a new server_status to the M&C database.
+        Add a new subsystem server_status to the M&C database.
 
         Parameters:
         ------------
+        subsytem: string
+            name of subsytem. Must be one of ['rtp']
         hostname:
             name of server
         ip_address:
@@ -151,19 +153,27 @@ class MCSession(Session):
         network_bandwidth_mbs:
             Network bandwidth in MB/s, 5 min average. Can be null if not applicable
         """
-        from .server_status import ServerStatus
+        if subsystem == 'rtp':
+            from .rtp import RTPServerStatus as ServerStatus
+        elif subsystem is None:
+            from .server_status import ServerStatus
+        else:
+            raise ValueError('subsystem must be one of: [None, "rtp"]')
 
         self.add(ServerStatus.new_status(hostname, ip_address, system_time, num_cores,
                                          cpu_load_pct, uptime_days, memory_used_pct,
                                          memory_size_gb, disk_space_pct, disk_size_gb,
                                          network_bandwidth_mbs=network_bandwidth_mbs))
 
-    def get_server_status(self, starttime, stoptime=None, hostname=None):
+    def get_server_status(self, subsystem, starttime, stoptime=None, hostname=None):
         """
-        Get server_status record(s) from the M&C database.
+        Get subsystem server_status record(s) from the M&C database.
 
         Parameters:
         ------------
+        subsytem: string
+            name of subsytem. Must be one of ['rtp']
+
         starttime: astropy time object
             time to look for records after
 
@@ -178,7 +188,12 @@ class MCSession(Session):
         --------
         list of ServerStatus objects
         """
-        from .server_status import ServerStatus
+        if subsystem == 'rtp':
+            from .rtp import RTPServerStatus as ServerStatus
+        elif subsystem is None:
+            from .server_status import ServerStatus
+        else:
+            raise ValueError('subsystem must be one of: [None, "rtp"]')
 
         status_list = self._time_filter(ServerStatus, 'mc_time', starttime,
                                         stoptime=stoptime, filter_column='hostname',

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -1,0 +1,237 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+from sqlalchemy.orm import Session
+from astropy.time import Time
+import datetime
+"""
+Primary session object which handles most DB queries.
+
+See INSTALL.md in the Git repository for instructions on how to initialize
+your database and configure M&C to find it.
+"""
+
+
+class MCSession(Session):
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, etype, evalue, etb):
+        if etype is not None:
+            self.rollback()  # exception raised
+        else:
+            self.commit()  # success
+        self.close()
+        return False  # propagate exception if any occurred
+
+    def add_obs(self, starttime, stoptime, obsid=None):
+        """
+        Add a new observation to the M&C database.
+
+        Parameters:
+        ------------
+        starttime: astropy time object
+            observation starttime
+        stoptime: astropy time object
+            observation stoptime
+        obsid: long integer
+            observation identification number. If not provided, will be set
+            to the gps second corresponding to the starttime using floor.
+        """
+        from .observations import Observation
+
+        self.add(Observation.new_observation(starttime, stoptime, obsid=obsid))
+
+    def get_obs(self, obsid=None):
+        """
+        Get observation(s) from the M&C database.
+
+        Parameters:
+        ------------
+        obsid: long integer
+            observation identification number, generally the gps second
+            corresponding to the observation start time.
+            if not set, all obsids will be returned.
+
+        Returns:
+        --------
+        list of Observation objects
+        """
+        from .observations import Observation
+
+        if obsid is None:
+            obs_list = self.query(Observation).all()
+        else:
+            obs_list = self.query(Observation).filter_by(obsid=obsid).all()
+
+        return obs_list
+
+    def add_server_status(self, hostname, ip_address, system_time, num_cores,
+                          cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
+                          disk_space_pct, disk_size_gb, network_bandwidth_mbs=None):
+        """
+        Add a new server_status to the M&C database.
+
+        Parameters:
+        ------------
+        hostname:
+            name of server
+        ip_address:
+            IP address of server
+        system_time:
+            time report sent by server
+        num_cores:
+            number of cores on server
+        cpu_load_pct:
+            CPU load percent = total load / num_cores, 5 min average
+        uptime_days:
+            server uptime in decimal days
+        memory_used_pct:
+            Percent of memory used, 5 min average
+        memory_size_gb:
+            Amount of memory on server in GB
+        disk_space_pct:
+            Percent of disk used
+        disk_size_gb:
+            Amount of disk space on server in GB
+        network_bandwidth_mbs:
+            Network bandwidth in MB/s. Can be null if not applicable
+        """
+        from .server_status import ServerStatus
+
+        self.add(ServerStatus.new_status(hostname, ip_address, system_time, num_cores,
+                                         cpu_load_pct, uptime_days, memory_used_pct,
+                                         memory_size_gb, disk_space_pct, disk_size_gb,
+                                         network_bandwidth_mbs=network_bandwidth_mbs))
+
+    def get_server_status(self, starttime, stoptime=None, hostname=None):
+        """
+        Get server_status record(s) from the M&C database.
+
+        Parameters:
+        ------------
+        starttime: datetime
+            time to look for records after
+
+        stoptime: datetime
+            last time to get records for. If none, only the first record after starttime will be returned.
+
+        hostname: string
+            hostname to get records for. If none, all hostnames will be included.
+
+        Returns:
+        --------
+        list of ServerStatus objects
+        """
+        from .server_status import ServerStatus
+
+        if not isinstance(starttime, datetime.datetime):
+            raise ValueError('unrecognized "starttime" value: %r' % (starttime,))
+
+        if stoptime is not None:
+            if not isinstance(stoptime, datetime.datetime):
+                raise ValueError('unrecognized "stoptime" value: %r' % (stoptime,))
+
+        if stoptime is not None:
+            if hostname is not None:
+                status_list = self.query(ServerStatus).filter(
+                    ServerStatus.hostname == hostname,
+                    ServerStatus.mc_time.between(starttime, stoptime)).all()
+            else:
+                status_list = self.query(ServerStatus).filter(
+                    ServerStatus.mc_time.between(starttime, stoptime)).all()
+        else:
+            if hostname is not None:
+                status_list = self.query(ServerStatus).filter(
+                    ServerStatus.hostname == hostname,
+                    ServerStatus.mc_time >= starttime).order_by(
+                        ServerStatus.mc_time).limit(1).all()
+            else:
+                status_list = self.query(ServerStatus).filter(
+                    ServerStatus.mc_time >= starttime).order_by(
+                        ServerStatus.mc_time).limit(1).all()
+
+        return status_list
+
+    def add_paper_temps(self, read_time, temp_list):
+        """
+        Add a new PaperTemperatures record to the M&C database.
+
+        This list is usually parsed from the text file on tmon.
+
+        Parameters:
+        ------------
+        read_time: float or astropy time object
+            if float: jd time of temperature read
+
+        temp_list: List of temperatures. See temperatures.py for details.
+        """
+        from .temperatures import PaperTemperatures
+
+        self.add(PaperTemperatures.new_from_text_row(read_time, temp_list))
+
+    def get_paper_temps(self, starttime, stoptime=None):
+        """
+        get sets of temperature records.
+
+        If only starttime is specified, get first record after starttime,
+           if both starttime and stoptime are specified, get records between
+           starttime and stoptime.
+
+        Parameters:
+        ------------
+        starttime: float or astropy time object
+            if float: jd time of starttime
+
+        stoptime: float or astropy time object
+            if float: jd time of temperature read
+
+        """
+        from .temperatures import PaperTemperatures
+
+        if isinstance(starttime, Time):
+            t_start = starttime.utc
+        elif isinstance(starttime, float):
+            t_start = Time(starttime, format='jd', scale='utc')
+        else:
+            raise ValueError('unrecognized "starttime" value: %r' % (starttime,))
+
+        if stoptime is not None:
+            if isinstance(stoptime, Time):
+                t_stop = stoptime.utc
+            elif isinstance(starttime, float):
+                t_stop = Time(stoptime, format='jd', scale='utc')
+            else:
+                raise ValueError('unrecognized "stoptime" value: %r' % (stoptime,))
+
+        if stoptime is not None:
+            ptemp_list = self.query(PaperTemperatures).filter(
+                PaperTemperatures.gps_time.between(t_start.gps, t_stop.gps)).all()
+        else:
+            ptemp_list = self.query(PaperTemperatures).filter(
+                PaperTemperatures.gps_time >= t_start.gps).order_by(
+                    PaperTemperatures.gps_time).limit(1).all()
+
+        return ptemp_list
+
+    def get_station_type(self):
+        """
+        returns a dictionary of sub-arrays
+             [prefix]{'Description':'...', 'plot_marker':'...', 'stations':[]}
+        """
+        from .geo_location import GeoLocation
+        from .geo_location import StationType
+
+        station_data = self.query(StationType).all()
+        stations = {}
+        for sta in station_data:
+            stations[sta.prefix] = {'Name': sta.station_type_name, 'Description': sta.description,
+                                    'Marker': sta.plot_marker, 'Stations': []}
+        locations = self.query(GeoLocation).all()
+        for loc in locations:
+            for k in stations.keys():
+                if loc.station_name[:len(k)] == k:
+                    stations[k]['Stations'].append(loc.station_name)
+        return stations

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -40,25 +40,19 @@ class MCSession(Session):
 
         if stoptime is not None:
             if filter_value is not None:
-                print('case 1')
                 result_list = self.query(table).filter(
                     getattr(table, filter_column) == filter_value,
                     getattr(table, time_column).between(starttime.gps, stoptime.gps)).all()
             else:
-                print('case 2')
                 result_list = self.query(table).filter(
                     getattr(table, time_column).between(starttime.gps, stoptime.gps)).all()
         else:
             if filter_value is not None:
-                print('case 3')
                 result_list = self.query(table).filter(
                     getattr(table, filter_column) == filter_value,
                     getattr(table, time_column) >= starttime.gps).order_by(
                         getattr(table, time_column)).limit(1).all()
             else:
-                print('case 4')
-                # print(table, starttime.gps)
-                # print(self.query(table).all())
                 result_list = self.query(table).filter(
                     getattr(table, time_column) >= starttime.gps).order_by(
                         getattr(table, time_column)).limit(1).all()
@@ -129,7 +123,7 @@ class MCSession(Session):
         Parameters:
         ------------
         subsytem: string
-            name of subsytem. Must be one of ['rtp']
+            name of subsytem. Must be one of ['rtp', 'lib']
         hostname:
             name of server
         ip_address:
@@ -155,10 +149,10 @@ class MCSession(Session):
         """
         if subsystem == 'rtp':
             from .rtp import RTPServerStatus as ServerStatus
-        elif subsystem is None:
-            from .server_status import ServerStatus
+        elif subsystem is 'lib':
+            from .librarian import LibServerStatus as ServerStatus
         else:
-            raise ValueError('subsystem must be one of: [None, "rtp"]')
+            raise ValueError('subsystem must be one of: ["rtp", "lib"]')
 
         self.add(ServerStatus.new_status(hostname, ip_address, system_time, num_cores,
                                          cpu_load_pct, uptime_days, memory_used_pct,
@@ -172,7 +166,7 @@ class MCSession(Session):
         Parameters:
         ------------
         subsytem: string
-            name of subsytem. Must be one of ['rtp']
+            name of subsytem. Must be one of ['rtp', 'lib']
 
         starttime: astropy time object
             time to look for records after
@@ -190,10 +184,10 @@ class MCSession(Session):
         """
         if subsystem == 'rtp':
             from .rtp import RTPServerStatus as ServerStatus
-        elif subsystem is None:
-            from .server_status import ServerStatus
+        elif subsystem is 'lib':
+            from .librarian import LibServerStatus as ServerStatus
         else:
-            raise ValueError('subsystem must be one of: [None, "rtp"]')
+            raise ValueError('subsystem must be one of: ["rtp", "lib"]')
 
         status_list = self._time_filter(ServerStatus, 'mc_time', starttime,
                                         stoptime=stoptime, filter_column='hostname',

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -128,11 +128,11 @@ class MCSession(Session):
         from .server_status import ServerStatus
 
         if not isinstance(starttime, datetime.datetime):
-            raise ValueError('unrecognized "starttime" value: %r' % (starttime,))
+            raise ValueError('starttime must be a datetime. value was: %r' % (starttime,))
 
         if stoptime is not None:
             if not isinstance(stoptime, datetime.datetime):
-                raise ValueError('unrecognized "stoptime" value: %r' % (stoptime,))
+                raise ValueError('stoptime must be a datetime. value was: %r' % (stoptime,))
 
         if stoptime is not None:
             if hostname is not None:
@@ -197,11 +197,11 @@ class MCSession(Session):
         from .rtp import RTPStatus
 
         if not isinstance(starttime, datetime.datetime):
-            raise ValueError('unrecognized "starttime" value: %r' % (starttime,))
+            raise ValueError('starttime must be a datetime. value was: %r' % (starttime,))
 
         if stoptime is not None:
             if not isinstance(stoptime, datetime.datetime):
-                raise ValueError('unrecognized "stoptime" value: %r' % (stoptime,))
+                raise ValueError('stoptime must be a datetime. value was: %r' % (stoptime,))
 
         if stoptime is not None:
             status_list = self.query(RTPStatus).filter(

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -176,6 +176,59 @@ class MCSession(Session):
 
         return status_list
 
+    def add_lib_status(self, time, num_files, data_volume_gb, free_space_gb,
+                       upload_min_elapsed, num_processes, git_version, git_hash):
+        """
+        Add a new lib_status object.
+
+        Parameters:
+        ------------
+        time: astropy time object
+            time of this status
+        num_files: integer
+            number of files in librarian
+        data_volume_gb: float
+            data volume in GB
+        free_space_gb: float
+            free space in GB
+        upload_min_elapsed: float
+            minutes since last file upload
+        num_processes: integer
+            number of background tasks running
+        git_version: string
+            Librarian git version
+        git_hash: string
+            Librarian git hash
+        """
+        from .librarian import LibStatus
+
+        self.add(LibStatus.new_status(time, num_files, data_volume_gb,
+                                      free_space_gb, upload_min_elapsed,
+                                      num_processes, git_version, git_hash))
+
+    def get_lib_status(self, starttime, stoptime=None):
+        """
+        Get lib_status record(s) from the M&C database.
+
+        Parameters:
+        ------------
+        starttime: astropy time object
+            time to look for records after
+
+        stoptime: astropy time object
+            last time to get records for. If none, only the first record after starttime will be returned.
+
+        Returns:
+        --------
+        list of RTPStatus objects
+        """
+        from .librarian import LibStatus
+
+        status_list = self._time_filter(LibStatus, 'time', starttime,
+                                        stoptime=stoptime)
+
+        return status_list
+
     def add_rtp_status(self, time, status, event_min_elapsed, num_processes,
                        restart_hours_elapsed):
         """
@@ -201,7 +254,7 @@ class MCSession(Session):
 
     def get_rtp_status(self, starttime, stoptime=None):
         """
-        Get server_status record(s) from the M&C database.
+        Get rtp_status record(s) from the M&C database.
 
         Parameters:
         ------------

--- a/hera_mc/observations.py
+++ b/hera_mc/observations.py
@@ -8,10 +8,10 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
+from math import floor
 from astropy.time import Time
 from astropy.coordinates import EarthLocation, Angle
-from sqlalchemy import Column, BigInteger, String, Float
-from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
+from sqlalchemy import Column, BigInteger, Float
 from hera_mc import geo_handling
 from . import MCDeclarativeBase
 
@@ -28,9 +28,15 @@ class Observation(MCDeclarativeBase):
     """
     __tablename__ = 'hera_obs'
     obsid = Column(BigInteger, primary_key=True)
-    start_time_jd = Column(DOUBLE_PRECISION, nullable=False)
-    stop_time_jd = Column(DOUBLE_PRECISION, nullable=False)
-    lst_start_hr = Column(DOUBLE_PRECISION, nullable=False)
+    start_time_jd = Column(Float, nullable=False)  # Float is mapped to DOUBLE PRECISION in postgresql
+    stop_time_jd = Column(Float, nullable=False)
+    lst_start_hr = Column(Float, nullable=False)
+
+    # tolerances set to 1ms
+    tols = {'obsid': {'atol': .1, 'rtol': 0},
+            'start_time_jd': {'atol': 1e-3 / (3600. * 24.), 'rtol': 0},
+            'stop_time_jd': {'atol': 1e-3 / (3600. * 24.), 'rtol': 0},
+            'lst_start_hr': {'atol': 1e-3 / (3600), 'rtol': 0}}
 
     @classmethod
     def new_observation(cls, starttime, stoptime, obsid=None):
@@ -47,15 +53,18 @@ class Observation(MCDeclarativeBase):
             observation identification number. If not provided, will be set
             to the gps second corresponding to the starttime using floor.
         """
-        t_start = starttime.utc
-        t_stop = stoptime.utc
+        if not isinstance(starttime, Time):
+            raise ValueError('starttime must be an astropy Time object')
+        if not isinstance(stoptime, Time):
+            raise ValueError('starttime must be an astropy Time object')
+        starttime = starttime.utc
+        stoptime = stoptime.utc
 
         if obsid is None:
-            from math import floor
-            obsid = floor(t_start.gps)
+            obsid = floor(starttime.gps)
 
         hera_cofa = geo_handling.cofa()
-        t_start.location = EarthLocation.from_geodetic(hera_cofa.lon, hera_cofa.lat)
-        return cls(obsid=obsid, start_time_jd=t_start.jd,
-                   stop_time_jd=t_stop.jd,
-                   lst_start_hr=t_start.sidereal_time('apparent').hour)
+        starttime.location = EarthLocation.from_geodetic(hera_cofa.lon, hera_cofa.lat)
+        return cls(obsid=obsid, start_time_jd=starttime.jd,
+                   stop_time_jd=stoptime.jd,
+                   lst_start_hr=starttime.sidereal_time('apparent').hour)

--- a/hera_mc/observations.py
+++ b/hera_mc/observations.py
@@ -32,18 +32,6 @@ class Observation(MCDeclarativeBase):
     stop_time_jd = Column(DOUBLE_PRECISION, nullable=False)
     lst_start_hr = Column(DOUBLE_PRECISION, nullable=False)
 
-    def __repr__(self):
-        return ("<Observation('{self.obsid}', '{self.start_time_jd}', "
-                "'{self.stop_time_jd}', '{self.lst_start_hr}')>".format(
-                    self=self))
-
-    def __eq__(self, other):
-        return isinstance(other, Observation) and (
-            other.obsid == self.obsid and
-            np.allclose(other.start_time_jd, self.start_time_jd) and
-            np.allclose(other.stop_time_jd, self.stop_time_jd) and
-            np.allclose(other.lst_start_hr, self.lst_start_hr))
-
     @classmethod
     def new_observation(cls, starttime, stoptime, obsid=None):
         """

--- a/hera_mc/observations.py
+++ b/hera_mc/observations.py
@@ -45,10 +45,9 @@ class Observation(MCDeclarativeBase):
             np.allclose(other.lst_start_hr, self.lst_start_hr))
 
     @classmethod
-    def new_with_astropy(cls, starttime, stoptime, obsid=None):
+    def new_observation(cls, starttime, stoptime, obsid=None):
         """
-        Add an observation to the M&C database, using Astropy to compute
-        the LST.
+        Create a new observation object using Astropy to compute the LST.
 
         Parameters:
         ------------

--- a/hera_mc/observations.py
+++ b/hera_mc/observations.py
@@ -8,38 +8,44 @@
 from __future__ import absolute_import, division, print_function
 
 import numpy as np
-from math import floor
 from astropy.time import Time
 from astropy.coordinates import EarthLocation, Angle
 from sqlalchemy import Column, BigInteger, Float
+from sqlalchemy.ext.hybrid import hybrid_property
+
 from hera_mc import geo_handling
-from . import MCDeclarativeBase
+from . import MCDeclarativeBase, DEFAULT_GPS_TOL, DEFAULT_DAY_TOL, DEFAULT_HOUR_TOL
 
 
 class Observation(MCDeclarativeBase):
     """
     Definition of hera_obs table.
 
-    obsid: observation identification number, generally equal to the
-        start time in gps seconds (long integer)
-    starttime: observation start time in jd (double)
-    stoptime: observation stop time in jd (double)
-    lststart: observation start time in lst (double)
+    obsid: observation identification number, generally equal to the floor of
+        the start time in gps seconds (long integer)
+    starttime: observation start time in gps seconds (double)
+    stoptime: observation stop time in gps seconds (double)
+    jd_start: observation start time in JDs, calculated from starttime (double)
+    lststart: observation start time in lst, calculated from starttime and
+        HERA array location (double)
     """
     __tablename__ = 'hera_obs'
     obsid = Column(BigInteger, primary_key=True)
-    start_time_jd = Column(Float, nullable=False)  # Float is mapped to DOUBLE PRECISION in postgresql
-    stop_time_jd = Column(Float, nullable=False)
+    starttime = Column(Float, nullable=False)  # Float is mapped to DOUBLE PRECISION in postgresql
+    stoptime = Column(Float, nullable=False)
+    jd_start = Column(Float, nullable=False)
     lst_start_hr = Column(Float, nullable=False)
 
     # tolerances set to 1ms
-    tols = {'obsid': {'atol': .1, 'rtol': 0},
-            'start_time_jd': {'atol': 1e-3 / (3600. * 24.), 'rtol': 0},
-            'stop_time_jd': {'atol': 1e-3 / (3600. * 24.), 'rtol': 0},
-            'lst_start_hr': {'atol': 1e-3 / (3600), 'rtol': 0}}
+    tols = {'starttime': DEFAULT_GPS_TOL, 'stoptime': DEFAULT_GPS_TOL,
+            'jd_start': DEFAULT_DAY_TOL, 'lst_start_hr': DEFAULT_HOUR_TOL}
+
+    @hybrid_property
+    def length(self):
+        return self.stoptime - self.starttime
 
     @classmethod
-    def new_observation(cls, starttime, stoptime, obsid=None):
+    def create(cls, starttime, stoptime, obsid):
         """
         Create a new observation object using Astropy to compute the LST.
 
@@ -50,21 +56,23 @@ class Observation(MCDeclarativeBase):
         stoptime: astropy time object
             observation stoptime
         obsid: long integer
-            observation identification number. If not provided, will be set
-            to the gps second corresponding to the starttime using floor.
+            observation identification number.
         """
         if not isinstance(starttime, Time):
             raise ValueError('starttime must be an astropy Time object')
         if not isinstance(stoptime, Time):
             raise ValueError('starttime must be an astropy Time object')
-        starttime = starttime.utc
-        stoptime = stoptime.utc
+        if not isinstance(obsid, (int, long)):
+            raise ValueError('obsid must be an integer')
+        if abs(float(obsid) - starttime.gps) > 1.5:
+            raise ValueError('obsid should be close to the starttime in gps seconds')
 
-        if obsid is None:
-            obsid = floor(starttime.gps)
+        # for jd need to ensure that we're in utc
+        starttime = starttime.utc
 
         hera_cofa = geo_handling.cofa()
         starttime.location = EarthLocation.from_geodetic(hera_cofa.lon, hera_cofa.lat)
-        return cls(obsid=obsid, start_time_jd=starttime.jd,
-                   stop_time_jd=stoptime.jd,
+
+        return cls(obsid=obsid, starttime=starttime.gps, stoptime=stoptime.gps,
+                   jd_start=starttime.jd,
                    lst_start_hr=starttime.sidereal_time('apparent').hour)

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -9,6 +9,11 @@
 from astropy.time import Time
 from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float, Enum
 from . import MCDeclarativeBase
+from .server_status import ServerStatus
+
+
+class RTPServerStatus(ServerStatus):
+    __tablename__ = 'rtp_server_status'
 
 rtp_process_enum = ['queued', 'started', 'finished', 'error']
 

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -12,7 +12,7 @@ class RTPStatus(MCDeclarativeBase):
     time: time of this status in gps seconds (double). Primary_key
     status: status (options TBD) (String)
     event_min_elapsed: minutes elapsed since last event (Float)
-    num_processes: number of processes on running (Integer)
+    num_processes: number of processes running (Integer)
     restart_hours_elapsed: hours elapsed since last restart (Float)
     """
     __tablename__ = 'rtp_status'
@@ -34,7 +34,7 @@ class RTPStatus(MCDeclarativeBase):
 
         Parameters:
         ------------
-        time: datetime
+        time: astropy time object
             time of this status
         status: string
             status (options TBD)
@@ -76,7 +76,7 @@ class RTPProcessEvent(MCDeclarativeBase):
 
         Parameters:
         ------------
-        time: datetime
+        time: astropy time object
             time of this event
         obsid: long
             observation obsid (Foreign key into Observation)
@@ -117,7 +117,7 @@ class RTPProcessRecord(MCDeclarativeBase):
 
         Parameters:
         ------------
-        time: datetime
+        time: astropy time object
             time of this event
         obsid: long
             observation obsid (Foreign key into Observation)

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, Integer, String, Float, DateTime
+from . import MCDeclarativeBase
+
+
+class RTPStatus(MCDeclarativeBase):
+    """
+    Definition of rtp_status table.
+
+    time: time of this status (DateTime). Primary_key
+    status: status (options TBD) (String)
+    event_min_elapsed: minutes elapsed since last event (Float)
+    num_processes: number of processes on running (Integer)
+    restart_hours_elapsed: hours elapsed since last restart (Float)
+    """
+    __tablename__ = 'rtp_status'
+    time = Column(DateTime(timezone=True), primary_key=True)
+    status = Column(String(64), nullable=False)
+    event_min_elapsed = Column(Float, nullable=False)
+    num_processes = Column(Integer, nullable=False)
+    restart_hours_elapsed = Column(Float, nullable=False)
+
+    @classmethod
+    def new_status(cls, time, status, event_min_elapsed, num_processes,
+                   restart_hours_elapsed):
+        """
+        Create a new rtp_status object.
+
+        Parameters:
+        ------------
+        time: datetime
+            time of this status
+        status: string
+            status (options TBD)
+        event_min_elapsed: float
+            minutes since last event
+        num_processes: integer
+            number of processes running
+        restart_hours_elapsed: float
+            hours since last restart
+        """
+
+        return cls(time=time, status=status, event_min_elapsed=event_min_elapsed,
+                   num_processes=num_processes, restart_hours_elapsed=restart_hours_elapsed)

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -1,14 +1,17 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2016 the HERA Collaboration
+# Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
-"""RTP tables
+"""
+RTP tables
 
+The columns in this module are documented in docs/mc_definition.tex,
+the documentation needs to be kept up to date with any changes.
 """
 
 from astropy.time import Time
 from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float, Enum
-from . import MCDeclarativeBase
+from . import MCDeclarativeBase, DEFAULT_GPS_TOL, DEFAULT_MIN_TOL, DEFAULT_HOUR_TOL
 from .server_status import ServerStatus
 
 rtp_process_enum = ['queued', 'started', 'finished', 'error']
@@ -35,13 +38,13 @@ class RTPStatus(MCDeclarativeBase):
     num_processes = Column(Integer, nullable=False)
     restart_hours_elapsed = Column(Float, nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0},
-            'event_min_elapsed': {'atol': 1e-3 * 60, 'rtol': 0},
-            'restart_hours_elapsed': {'atol': 1e-3 * 3600, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL,
+            'event_min_elapsed': DEFAULT_MIN_TOL,
+            'restart_hours_elapsed': DEFAULT_HOUR_TOL}
 
     @classmethod
-    def new_status(cls, time, status, event_min_elapsed, num_processes,
-                   restart_hours_elapsed):
+    def create(cls, time, status, event_min_elapsed, num_processes,
+               restart_hours_elapsed):
         """
         Create a new rtp_status object.
 
@@ -60,7 +63,7 @@ class RTPStatus(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, status=status, event_min_elapsed=event_min_elapsed,
                    num_processes=num_processes, restart_hours_elapsed=restart_hours_elapsed)
@@ -79,11 +82,10 @@ class RTPProcessEvent(MCDeclarativeBase):
     obsid = Column(BigInteger, ForeignKey('hera_obs.obsid'), primary_key=True)
     event = Column(Enum(*rtp_process_enum, name='rtp_process_enum'), nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0},
-            'obsid': {'atol': 0.1, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_process_event(cls, time, obsid, event):
+    def create(cls, time, obsid, event):
         """
         Create a new rtp_process_event object.
 
@@ -98,7 +100,7 @@ class RTPProcessEvent(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, obsid=obsid, event=event)
 
@@ -120,11 +122,10 @@ class RTPProcessRecord(MCDeclarativeBase):
     git_version = Column(String(32), nullable=False)
     git_hash = Column(String(64), nullable=False)
 
-    tols = {'time': {'atol': 1e-3, 'rtol': 0},
-            'obsid': {'atol': 0.1, 'rtol': 0}}
+    tols = {'time': DEFAULT_GPS_TOL}
 
     @classmethod
-    def new_process_record(cls, time, obsid, pipeline_list, git_version, git_hash):
+    def create(cls, time, obsid, pipeline_list, git_version, git_hash):
         """
         Create a new rtp_process_record object.
 
@@ -143,7 +144,7 @@ class RTPProcessRecord(MCDeclarativeBase):
         """
         if not isinstance(time, Time):
             raise ValueError('time must be an astropy Time object')
-        time = time.utc.gps
+        time = time.gps
 
         return cls(time=time, obsid=obsid, pipeline_list=pipeline_list,
                    git_version=git_version, git_hash=git_hash)

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -1,23 +1,30 @@
-from sqlalchemy import Column, Integer, String, Float, DateTime
+from astropy.time import Time
+from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float, Enum
 from . import MCDeclarativeBase
+
+rtp_process_enum = ['queued', 'started', 'finished', 'error']
 
 
 class RTPStatus(MCDeclarativeBase):
     """
     Definition of rtp_status table.
 
-    time: time of this status (DateTime). Primary_key
+    time: time of this status in gps seconds (double). Primary_key
     status: status (options TBD) (String)
     event_min_elapsed: minutes elapsed since last event (Float)
     num_processes: number of processes on running (Integer)
     restart_hours_elapsed: hours elapsed since last restart (Float)
     """
     __tablename__ = 'rtp_status'
-    time = Column(DateTime(timezone=True), primary_key=True)
-    status = Column(String(64), nullable=False)
+    time = Column(Float, primary_key=True)
+    status = Column(String(64), nullable=False)  # should this be an enum? or text?
     event_min_elapsed = Column(Float, nullable=False)
     num_processes = Column(Integer, nullable=False)
     restart_hours_elapsed = Column(Float, nullable=False)
+
+    tols = {'time': {'atol': 1e-3, 'rtol': 0},
+            'event_min_elapsed': {'atol': 1e-3 * 60, 'rtol': 0},
+            'restart_hours_elapsed': {'atol': 1e-3 * 3600, 'rtol': 0}}
 
     @classmethod
     def new_status(cls, time, status, event_min_elapsed, num_processes,
@@ -38,6 +45,92 @@ class RTPStatus(MCDeclarativeBase):
         restart_hours_elapsed: float
             hours since last restart
         """
+        if not isinstance(time, Time):
+            raise ValueError('time must be an astropy Time object')
+        time = time.utc.gps
 
         return cls(time=time, status=status, event_min_elapsed=event_min_elapsed,
                    num_processes=num_processes, restart_hours_elapsed=restart_hours_elapsed)
+
+
+class RTPProcessEvent(MCDeclarativeBase):
+    """
+    Definition of rtp_process_event table.
+
+    time: time of this status in gps seconds (double). Part of primary_key.
+    obsid: observation obsid (Long).  Part of primary_key. Foreign key into Observation table
+    event: one of ["queued", "started", "finished", "error"] (rtp_process_enum)
+    """
+    __tablename__ = 'rtp_process_event'
+    time = Column(Float, primary_key=True)
+    obsid = Column(BigInteger, ForeignKey('hera_obs.obsid'), primary_key=True)
+    event = Column(Enum(*rtp_process_enum, name='rtp_process_enum'), nullable=False)
+
+    tols = {'time': {'atol': 1e-3, 'rtol': 0},
+            'obsid': {'atol': 0.1, 'rtol': 0}}
+
+    @classmethod
+    def new_process_event(cls, time, obsid, event):
+        """
+        Create a new rtp_process_event object.
+
+        Parameters:
+        ------------
+        time: datetime
+            time of this event
+        obsid: long
+            observation obsid (Foreign key into Observation)
+        event: string
+            must be one of ["queued", "started", "finished", "error"]
+        """
+        if not isinstance(time, Time):
+            raise ValueError('time must be an astropy Time object')
+        time = time.utc.gps
+
+        return cls(time=time, obsid=obsid, event=event)
+
+
+class RTPProcessRecord(MCDeclarativeBase):
+    """
+    Definition of rtp_process_record table.
+
+    time: time of this status in gps seconds (double). Part of primary_key
+    obsid: observation obsid (Long). Part of primary_key. Foreign key into Observation table
+    pipeline_list: concatentated list of RTP tasks (String)
+    git_version: RTP git version (String)
+    git_hash: RTP git hash (String)
+    """
+    __tablename__ = 'rtp_process_record'
+    time = Column(Float, primary_key=True)
+    obsid = Column(BigInteger, ForeignKey('hera_obs.obsid'), primary_key=True)
+    pipeline_list = Column(Text, nullable=False)
+    git_version = Column(String(32), nullable=False)
+    git_hash = Column(String(64), nullable=False)
+
+    tols = {'time': {'atol': 1e-3, 'rtol': 0},
+            'obsid': {'atol': 0.1, 'rtol': 0}}
+
+    @classmethod
+    def new_process_record(cls, time, obsid, pipeline_list, git_version, git_hash):
+        """
+        Create a new rtp_process_record object.
+
+        Parameters:
+        ------------
+        time: datetime
+            time of this event
+        obsid: long
+            observation obsid (Foreign key into Observation)
+        pipeline_list: string
+            concatentated list of RTP tasks
+        git_version: string
+            RTP git version
+        git_hash: string
+            RTP git hash
+        """
+        if not isinstance(time, Time):
+            raise ValueError('time must be an astropy Time object')
+        time = time.utc.gps
+
+        return cls(time=time, obsid=obsid, pipeline_list=pipeline_list,
+                   git_version=git_version, git_hash=git_hash)

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -1,3 +1,11 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""RTP tables
+
+"""
+
 from astropy.time import Time
 from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Float, Enum
 from . import MCDeclarativeBase

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -11,11 +11,11 @@ from sqlalchemy import Column, ForeignKey, Integer, BigInteger, String, Text, Fl
 from . import MCDeclarativeBase
 from .server_status import ServerStatus
 
+rtp_process_enum = ['queued', 'started', 'finished', 'error']
+
 
 class RTPServerStatus(ServerStatus):
     __tablename__ = 'rtp_server_status'
-
-rtp_process_enum = ['queued', 'started', 'finished', 'error']
 
 
 class RTPStatus(MCDeclarativeBase):

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -1,5 +1,6 @@
 from sqlalchemy import Column, Integer, String, Float, DateTime
 from . import MCDeclarativeBase
+import datetime
 
 
 class ServerStatus(MCDeclarativeBase):
@@ -35,9 +36,9 @@ class ServerStatus(MCDeclarativeBase):
 
     def __repr__(self):
         return ("<ServerStatus('{self.hostname}', '{self.mc_time}', "
-                "'{self.ip_address}', '{self.system_time}, '{self.num_cores}'"
-                "'{self.cpu_load_pct}', '{self.uptime_days}, '{self.memory_used_pct}'"
-                "'{self.memory_size_gb}', '{self.disk_space_pct}'"
+                "'{self.ip_address}', '{self.system_time}, '{self.num_cores}', "
+                "'{self.cpu_load_pct}', '{self.uptime_days}, '{self.memory_used_pct}', "
+                "'{self.memory_size_gb}', '{self.disk_space_pct}', "
                 "'{self.disk_size_gb}', '{self.network_bandwidth_mbs}')>".format(
                     self=self))
 
@@ -63,3 +64,44 @@ class ServerStatus(MCDeclarativeBase):
         else:
             print('Classes do not match')
             return False
+
+    @classmethod
+    def new_status(cls, hostname, ip_address, system_time, num_cores,
+                   cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
+                   disk_space_pct, disk_size_gb, network_bandwidth_mbs=None):
+        """
+        Create a new server_status object.
+
+        Parameters:
+        ------------
+        hostname: string
+            name of server
+        ip_address: string
+            IP address of server
+        system_time: datetime
+            time report sent by server
+        num_cores: integer
+            number of cores on server
+        cpu_load_pct: float
+            CPU load percent = total load / num_cores, 5 min average
+        uptime_days: float
+            server uptime in decimal days
+        memory_used_pct: float
+            Percent of memory used, 5 min average
+        memory_size_gb: float
+            Amount of memory on server in GB
+        disk_space_pct: float
+            Percent of disk used
+        disk_size_gb: float
+            Amount of disk space on server in GB
+        network_bandwidth_mbs: float
+            Network bandwidth in MB/s. Can be null if not applicable
+        """
+        mc_time = datetime.datetime.now()
+
+        return cls(hostname=hostname, mc_time=mc_time, ip_address=ip_address,
+                   system_time=system_time, num_cores=num_cores,
+                   cpu_load_pct=cpu_load_pct, uptime_days=uptime_days,
+                   memory_used_pct=memory_used_pct, memory_size_gb=memory_size_gb,
+                   disk_space_pct=disk_space_pct, disk_size_gb=disk_size_gb,
+                   network_bandwidth_mbs=network_bandwidth_mbs)

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -74,7 +74,6 @@ class ServerStatus(MCDeclarativeBase):
         if not isinstance(system_time, Time):
             raise ValueError('system_time must be an astropy Time object')
         system_time = system_time.utc.gps
-        print('new_status: ', '{0:.10f}'.format(system_time))
 
         return cls(hostname=hostname, mc_time=mc_time, ip_address=ip_address,
                    system_time=system_time, num_cores=num_cores,

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -26,7 +26,7 @@ class ServerStatus(MCDeclarativeBase):
     memory_size_gb: Amount of memory on server in GB (Float)
     disk_space_pct: Percent of disk used (Float)
     disk_size_gb: Amount of disk space on server in GB (Float)
-    network_bandwidth_mbs: Network bandwidth in MB/s. Can be null if not applicable
+    network_bandwidth_mbs: Network bandwidth in MB/s, 5 min average. Can be null if not applicable
     """
     __tablename__ = 'server_status'
     hostname = Column(String(32), primary_key=True)
@@ -75,7 +75,7 @@ class ServerStatus(MCDeclarativeBase):
         disk_size_gb: float
             Amount of disk space on server in GB
         network_bandwidth_mbs: float
-            Network bandwidth in MB/s. Can be null if not applicable
+            Network bandwidth in MB/s, 5 min average. Can be null if not applicable
         """
         mc_time = Time.now().gps
 

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -1,0 +1,65 @@
+from sqlalchemy import Column, Integer, String, Float, DateTime
+from . import MCDeclarativeBase
+
+
+class ServerStatus(MCDeclarativeBase):
+    """
+    Definition of server_status table.
+
+    hostname: name of server (String). Part of primary_key
+    mc_time: time report received by M&C (DateTime). Part of primary_key
+    ip_address: IP address of server (String)
+    system_time: time report sent by server (DateTime)
+    num_cores: number of cores on server (Integer)
+    cpu_load_pct: CPU load percent = total load / num_cores, 5 min average (Float)
+    uptime_days: server uptime in decimal days (Float)
+    memory_used_pct: Percent of memory used, 5 min average (Float)
+    memory_size_gb: Amount of memory on server in GB (Float)
+    disk_space_pct: Percent of disk used (Float)
+    disk_size_gb: Amount of disk space on server in GB (Float)
+    network_bandwidth_mbs: Network bandwidth in MB/s. Can be null if not applicable
+    """
+    __tablename__ = 'server_status'
+    hostname = Column(String(32), primary_key=True)
+    mc_time = Column(DateTime(timezone=True), primary_key=True)
+    ip_address = Column(String(32), nullable=False)
+    system_time = Column(DateTime(timezone=True), nullable=False)
+    num_cores = Column(Integer, nullable=False)
+    cpu_load_pct = Column(Float, nullable=False)
+    uptime_days = Column(Float, nullable=False)
+    memory_used_pct = Column(Float, nullable=False)
+    memory_size_gb = Column(Float, nullable=False)
+    disk_space_pct = Column(Float, nullable=False)
+    disk_size_gb = Column(Float, nullable=False)
+    network_bandwidth_mbs = Column(Float)
+
+    def __repr__(self):
+        return ("<ServerStatus('{self.hostname}', '{self.mc_time}', "
+                "'{self.ip_address}', '{self.system_time}, '{self.num_cores}'"
+                "'{self.cpu_load_pct}', '{self.uptime_days}, '{self.memory_used_pct}'"
+                "'{self.memory_size_gb}', '{self.disk_space_pct}'"
+                "'{self.disk_size_gb}', '{self.network_bandwidth_mbs}')>".format(
+                    self=self))
+
+    def __eq__(self, other):
+        if isinstance(other, ServerStatus):
+            self_columns = [a for a in dir(self) if not a.startswith('__') and
+                            isinstance(a, Column)]
+            other_columns = [a for a in dir(other) if not a.startswith('__') and
+                             isinstance(a, Column)]
+            if set(self_columns) != set(other_columns):
+                print('Sets of columns do not match. Left is {lset},'
+                      ' right is {rset}'.format(lset=self_columns,
+                                                rset=other_columns))
+                return False
+
+            c_equal = True
+            for c in self_columns:
+                self_c = getattr(self, c)
+                other_c = getattr(other, c)
+                if self_c != other_c:
+                    c_equal = False
+            return c_equal
+        else:
+            print('Classes do not match')
+            return False

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -28,7 +28,7 @@ class ServerStatus(MCDeclarativeBase):
     disk_size_gb: Amount of disk space on server in GB (Float)
     network_bandwidth_mbs: Network bandwidth in MB/s, 5 min average. Can be null if not applicable
     """
-    __tablename__ = 'server_status'
+    __abstract__ = True
     hostname = Column(String(32), primary_key=True)
     mc_time = Column(Float(decimal_return_scale=3), primary_key=True)
     ip_address = Column(String(32), nullable=False)

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -35,15 +35,6 @@ class ServerStatus(MCDeclarativeBase):
     disk_size_gb = Column(Float, nullable=False)
     network_bandwidth_mbs = Column(Float)
 
-    def __repr__(self):
-        columns = self.__table__.columns.keys()
-        rep_str = '<' + self.__class__.__name__ + '('
-        for c in columns:
-            rep_str += str(getattr(self, c)) + ', '
-        rep_str = rep_str[0:-2]
-        rep_str += ')>'
-        return rep_str
-
     @classmethod
     def new_status(cls, hostname, ip_address, system_time, num_cores,
                    cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -1,14 +1,17 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2016 the HERA Collaboration
+# Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
-"""Common server_status table
+"""
+Common server_status table
 
+The columns in this module are documented in docs/mc_definition.tex,
+the documentation needs to be kept up to date with any changes.
 """
 
 from astropy.time import Time
 from sqlalchemy import Column, Integer, String, Float
-from . import MCDeclarativeBase
+from . import MCDeclarativeBase, DEFAULT_GPS_TOL, DEFAULT_DAY_TOL
 
 
 class ServerStatus(MCDeclarativeBase):
@@ -42,13 +45,13 @@ class ServerStatus(MCDeclarativeBase):
     disk_size_gb = Column(Float, nullable=False)
     network_bandwidth_mbs = Column(Float)
 
-    tols = {'mc_time': {'atol': 1e-3, 'rtol': 0},
-            'system_time': {'atol': 1e-3, 'rtol': 0}}
+    tols = {'mc_time': DEFAULT_GPS_TOL, 'system_time': DEFAULT_GPS_TOL,
+            'uptime_days': DEFAULT_DAY_TOL}
 
     @classmethod
-    def new_status(cls, hostname, ip_address, system_time, num_cores,
-                   cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
-                   disk_space_pct, disk_size_gb, network_bandwidth_mbs=None):
+    def create(cls, hostname, ip_address, system_time, num_cores,
+               cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
+               disk_space_pct, disk_size_gb, network_bandwidth_mbs=None):
         """
         Create a new server_status object.
 

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -36,38 +36,13 @@ class ServerStatus(MCDeclarativeBase):
     network_bandwidth_mbs = Column(Float)
 
     def __repr__(self):
-        return ("<ServerStatus('{self.hostname}', '{self.mc_time}', "
-                "'{self.ip_address}', '{self.system_time}, '{self.num_cores}', "
-                "'{self.cpu_load_pct}', '{self.uptime_days}, '{self.memory_used_pct}', "
-                "'{self.memory_size_gb}', '{self.disk_space_pct}', "
-                "'{self.disk_size_gb}', '{self.network_bandwidth_mbs}')>".format(
-                    self=self))
-
-    def __eq__(self, other):
-        if isinstance(other, ServerStatus):
-
-            self_columns = [a for a in dir(self) if not a.startswith('_')]
-            other_columns = [a for a in dir(other) if not a.startswith('_')]
-            if set(self_columns) != set(other_columns):
-                print('Sets of columns do not match. Left is {lset},'
-                      ' right is {rset}'.format(lset=self_columns,
-                                                rset=other_columns))
-                return False
-
-            c_equal = True
-            for c in self_columns:
-                self_c = getattr(self, c)
-                other_c = getattr(other, c)
-                if isinstance(self_c, datetime.datetime):
-                    self_c = self_c.astimezone(pytz.utc)
-                    other_c = other_c.astimezone(pytz.utc)
-                if self_c != other_c:
-                    print('column ', c, ' does not match. Left is ', self_c, ' Right is ', other_c)
-                    c_equal = False
-            return c_equal
-        else:
-            print('Classes do not match')
-            return False
+        columns = self.__table__.columns.keys()
+        rep_str = '<' + self.__class__.__name__ + '('
+        for c in columns:
+            rep_str += str(getattr(self, c)) + ', '
+        rep_str = rep_str[0:-2]
+        rep_str += ')>'
+        return rep_str
 
     @classmethod
     def new_status(cls, hostname, ip_address, system_time, num_cores,

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -1,3 +1,11 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Common server_status table
+
+"""
+
 from astropy.time import Time
 from sqlalchemy import Column, Integer, String, Float
 from . import MCDeclarativeBase

--- a/hera_mc/temperatures.py
+++ b/hera_mc/temperatures.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from astropy.time import Time
 from sqlalchemy import Column, Float
-from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
 
 from . import MCDeclarativeBase
 
@@ -35,8 +34,8 @@ class PaperTemperatures(MCDeclarativeBase):
     """
     __tablename__ = 'paper_temperatures'
 
-    gps_time = Column(DOUBLE_PRECISION, nullable=False, primary_key=True)
-    jd_time = Column(DOUBLE_PRECISION, nullable=False)
+    gps_time = Column(Float, nullable=False, primary_key=True)
+    jd_time = Column(Float, nullable=False)
     balun_east = Column(Float)
     cable_east = Column(Float)
     balun_west = Column(Float)
@@ -57,38 +56,6 @@ class PaperTemperatures(MCDeclarativeBase):
     rcvr_7b = Column(Float)
     rcvr_8a = Column(Float)
     rcvr_8b = Column(Float)
-
-    def __repr__(self):
-        return ("<PaperTemperatures('{self.gps_time}', '{self.jd_time}', "
-                "'{self.balun_east}', '{self.cable_east}', "
-                "'{self.balun_west}', '{self.cable_west}', "
-                "'{self.rcvr_1a}', '{self.rcvr_1b}', "
-                "'{self.rcvr_2a}', '{self.rcvr_2b}', "
-                "'{self.rcvr_3a}', '{self.rcvr_3b}', "
-                "'{self.rcvr_4a}', '{self.rcvr_4b}', "
-                "'{self.rcvr_5a}', '{self.rcvr_5b}', "
-                "'{self.rcvr_6a}', '{self.rcvr_6b}', "
-                "'{self.rcvr_7a}', '{self.rcvr_7b}', "
-                "'{self.rcvr_8a}', '{self.rcvr_8b}')>".format(self=self))
-
-    def __eq__(self, other):
-        if isinstance(other, PaperTemperatures):
-            attribute_list = [a for a in dir(self) if not a.startswith('__') and
-                              not callable(getattr(self, a))]
-            isequal = True
-            for a in attribute_list:
-                if isinstance(a, Column):
-                    self_col = getattr(self, a)
-                    other_col = getattr(other, a)
-                    if self_col != other_col:
-                        print('column {col} does not match. Left is {lval} '
-                              'and right is {rval}'.
-                              format(col=a, lval=str(self_col),
-                                     rval=str(other_col)))
-                        isequal = False
-            return isequal
-        else:
-            return False
 
     @classmethod
     def new_from_text_row(cls, read_time, temp_list):

--- a/hera_mc/tests/__init__.py
+++ b/hera_mc/tests/__init__.py
@@ -1,1 +1,22 @@
-## Blank init file
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Setup testing environment.
+
+"""
+
+from hera_mc import mc
+
+test_db = None
+
+
+def setup_package():
+    global test_db
+
+    test_db = mc.connect_to_mc_testing_db()
+    test_db.create_tables()
+
+
+def teardown_package():
+    test_db.drop_tables()

--- a/hera_mc/tests/test_connections.py
+++ b/hera_mc/tests/test_connections.py
@@ -20,7 +20,6 @@ class test_connections(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -28,7 +27,6 @@ class test_connections(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_add_part(self):
         self.test_session.add(part_connect.Parts())

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -20,7 +20,6 @@ class test_connections(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -28,7 +27,6 @@ class test_connections(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_add_part(self):
         self.test_session.add(geo_location.GeoLocation())

--- a/hera_mc/tests/test_host_status.py
+++ b/hera_mc/tests/test_host_status.py
@@ -20,7 +20,6 @@ class test_host_status(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -28,7 +27,6 @@ class test_host_status(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_add_one(self):
         self.test_session.add(host_status.HostStatus())

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -6,6 +6,7 @@
 
 """
 import unittest
+from math import floor
 import numpy as np
 from astropy.time import Time, TimeDelta
 
@@ -65,10 +66,13 @@ class test_hera_mc(unittest.TestCase):
         self.test_session.add_lib_status(*self.status_values)
 
         exp_columns = self.status_columns.copy()
-        exp_columns['time'] = exp_columns['time'].gps
+        exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = LibStatus(**exp_columns)
 
-        result = self.test_session.get_lib_status(self.status_columns['time'])[0]
+        result = self.test_session.get_lib_status(self.status_columns['time'] -
+                                                  TimeDelta(2, format='sec'))
+        self.assertEqual(len(result), 1)
+        result = result[0]
 
         self.assertTrue(result.isclose(expected))
 
@@ -81,12 +85,16 @@ class test_hera_mc(unittest.TestCase):
                                          self.status_columns['git_version'],
                                          self.status_columns['git_hash'])
 
-        result_mult = self.test_session.get_lib_status(self.status_columns['time'],
+        result_mult = self.test_session.get_lib_status(self.status_columns['time'] -
+                                                       TimeDelta(2, format='sec'),
                                                        stoptime=new_status_time)
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_lib_status(new_status_time)[0]
-        self.assertFalse(result2 == expected)
+        result2 = self.test_session.get_lib_status(new_status_time -
+                                                   TimeDelta(2, format='sec'))
+        self.assertEqual(len(result2), 1)
+        result2 = result2[0]
+        self.assertFalse(result2.isclose(expected))
 
     def test_errors_lib_status(self):
         self.assertRaises(ValueError, self.test_session.add_lib_status, 'foo',
@@ -99,7 +107,7 @@ class test_hera_mc(unittest.TestCase):
 
     def test_add_raid_status(self):
         exp_columns = self.raid_status_columns.copy()
-        exp_columns['time'] = exp_columns['time'].gps
+        exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = LibRAIDStatus(**exp_columns)
 
         self.test_session.add_lib_raid_status(*self.raid_status_values)
@@ -113,7 +121,8 @@ class test_hera_mc(unittest.TestCase):
 
         self.test_session.add_lib_raid_status(self.raid_status_values[0], 'raid_2',
                                               *self.raid_status_values[2:])
-        result_host = self.test_session.get_lib_raid_status(self.raid_status_columns['time'],
+        result_host = self.test_session.get_lib_raid_status(self.raid_status_columns['time'] -
+                                                            TimeDelta(2, format='sec'),
                                                             hostname=self.raid_status_columns['hostname'],
                                                             stoptime=self.raid_status_columns['time'] +
                                                             TimeDelta(2 * 60, format='sec'))
@@ -121,16 +130,20 @@ class test_hera_mc(unittest.TestCase):
         result_host = result_host[0]
         self.assertTrue(result_host.isclose(expected))
 
-        result_mult = self.test_session.get_lib_raid_status(self.raid_status_columns['time'],
+        result_mult = self.test_session.get_lib_raid_status(self.raid_status_columns['time'] -
+                                                            TimeDelta(2, format='sec'),
                                                             stoptime=self.raid_status_columns['time'] +
                                                             TimeDelta(2 * 60, format='sec'))
 
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_lib_raid_status(self.raid_status_columns['time'],
-                                                        hostname='raid_2')[0]
+        result2 = self.test_session.get_lib_raid_status(self.raid_status_columns['time'] -
+                                                        TimeDelta(2, format='sec'),
+                                                        hostname='raid_2')
+        self.assertEqual(len(result2), 1)
+        result2 = result2[0]
 
-        self.assertFalse(result2 == expected)
+        self.assertFalse(result2.isclose(expected))
 
     def test_errors_lib_raid_status(self):
         self.assertRaises(ValueError, self.test_session.add_lib_raid_status,
@@ -143,7 +156,7 @@ class test_hera_mc(unittest.TestCase):
 
     def test_add_raid_error(self):
         exp_columns = self.raid_error_columns.copy()
-        exp_columns['time'] = exp_columns['time'].gps
+        exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = LibRAIDErrors(**exp_columns)
 
         self.test_session.add_lib_raid_error(*self.raid_error_values)
@@ -157,7 +170,8 @@ class test_hera_mc(unittest.TestCase):
 
         self.test_session.add_lib_raid_error(self.raid_error_values[0], 'raid_2',
                                              *self.raid_error_values[2:])
-        result_host = self.test_session.get_lib_raid_error(self.raid_error_columns['time'],
+        result_host = self.test_session.get_lib_raid_error(self.raid_error_columns['time'] -
+                                                           TimeDelta(2, format='sec'),
                                                            hostname=self.raid_error_columns['hostname'],
                                                            stoptime=self.raid_error_columns['time'] +
                                                            TimeDelta(2 * 60, format='sec'))
@@ -165,16 +179,18 @@ class test_hera_mc(unittest.TestCase):
         result_host = result_host[0]
         self.assertTrue(result_host.isclose(expected))
 
-        result_mult = self.test_session.get_lib_raid_error(self.raid_error_columns['time'],
+        result_mult = self.test_session.get_lib_raid_error(self.raid_error_columns['time'] -
+                                                           TimeDelta(2, format='sec'),
                                                            stoptime=self.raid_error_columns['time'] +
                                                            TimeDelta(2 * 60, format='sec'))
 
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_lib_raid_error(self.raid_error_columns['time'],
+        result2 = self.test_session.get_lib_raid_error(self.raid_error_columns['time'] -
+                                                       TimeDelta(2, format='sec'),
                                                        hostname='raid_2')[0]
 
-        self.assertFalse(result2 == expected)
+        self.assertFalse(result2.isclose(expected))
 
     def test_errors_lib_raid_error(self):
         self.assertRaises(ValueError, self.test_session.add_lib_raid_error,
@@ -187,7 +203,7 @@ class test_hera_mc(unittest.TestCase):
 
     def test_add_remote_status(self):
         exp_columns = self.remote_status_columns.copy()
-        exp_columns['time'] = exp_columns['time'].gps
+        exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = LibRemoteStatus(**exp_columns)
 
         self.test_session.add_lib_remote_status(*self.remote_status_values)
@@ -202,7 +218,7 @@ class test_hera_mc(unittest.TestCase):
         self.test_session.add_lib_remote_status(self.remote_status_values[0], 'penn',
                                                 *self.remote_status_values[2:])
         result_remote = self.test_session.get_lib_remote_status(
-            self.remote_status_columns['time'],
+            self.remote_status_columns['time'] - TimeDelta(2, format='sec'),
             remote_name=self.remote_status_columns['remote_name'],
             stoptime=self.remote_status_columns['time'] + TimeDelta(2 * 60, format='sec'))
 
@@ -211,15 +227,18 @@ class test_hera_mc(unittest.TestCase):
         self.assertTrue(result_remote.isclose(expected))
 
         result_mult = self.test_session.get_lib_remote_status(
-            self.remote_status_columns['time'],
+            self.remote_status_columns['time'] - TimeDelta(2, format='sec'),
             stoptime=self.remote_status_columns['time'] + TimeDelta(2 * 60, format='sec'))
 
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_lib_remote_status(self.remote_status_columns['time'],
-                                                          remote_name='penn')[0]
+        result2 = self.test_session.get_lib_remote_status(self.remote_status_columns['time'] -
+                                                          TimeDelta(2, format='sec'),
+                                                          remote_name='penn')
+        self.assertEqual(len(result2), 1)
+        result2 = result2[0]
 
-        self.assertFalse(result2 == expected)
+        self.assertFalse(result2.isclose(expected))
 
     def test_errors_lib_remote_status(self):
         self.assertRaises(ValueError, self.test_session.add_lib_remote_status,
@@ -239,19 +258,23 @@ class test_hera_mc(unittest.TestCase):
         self.test_session.add_lib_file(*self.file_values)
 
         exp_columns = self.file_columns.copy()
-        exp_columns['time'] = exp_columns['time'].gps
+        exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = LibFiles(**exp_columns)
 
         result_file = self.test_session.get_lib_files(filename=self.file_columns['filename'])[0]
         self.assertTrue(result_file.isclose(expected))
 
-        result = self.test_session.get_lib_files(starttime=self.file_columns['time'])
+        result = self.test_session.get_lib_files(starttime=self.file_columns['time'] -
+                                                 TimeDelta(2, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result_obsid = self.test_session.get_lib_files(starttime=self.file_columns['time'],
-                                                       obsid=self.file_columns['obsid'])[0]
+        result_obsid = self.test_session.get_lib_files(starttime=self.file_columns['time'] -
+                                                       TimeDelta(2, format='sec'),
+                                                       obsid=self.file_columns['obsid'])
+        self.assertEqual(len(result_obsid), 1)
+        result_obsid = result_obsid[0]
         self.assertTrue(result_obsid.isclose(expected))
 
         new_file_time = self.file_columns['time'] + TimeDelta(3 * 60, format='sec')

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -1,0 +1,72 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Testing for `hera_mc.librarian`.
+
+"""
+import unittest
+import numpy as np
+from math import floor
+from astropy.time import Time, TimeDelta
+
+from hera_mc import mc
+from hera_mc.librarian import LibStatus
+
+
+class test_hera_mc(unittest.TestCase):
+
+    def setUp(self):
+        self.test_db = mc.connect_to_mc_testing_db()
+        self.test_db.create_tables()
+        self.test_conn = self.test_db.engine.connect()
+        self.test_trans = self.test_conn.begin()
+        self.test_session = mc.MCSession(bind=self.test_conn)
+
+        time = Time.now()
+        self.status_names = ['time', 'num_files', 'data_volume_gb',
+                             'free_space_gb', 'upload_min_elapsed',
+                             'num_processes', 'git_version', 'git_hash']
+        self.status_values = [time, 135, 3.6, 8.2, 12.2, 3, 'v0.0.1', 'lskdjf24l']
+        self.status_columns = dict(zip(self.status_names, self.status_values))
+
+    def tearDown(self):
+        self.test_trans.rollback()
+        self.test_conn.close()
+        self.test_db.drop_tables()
+
+    def test_add_rtp_status(self):
+        self.test_session.add_lib_status(*self.status_values)
+
+        exp_columns = self.status_columns.copy()
+        exp_columns['time'] = exp_columns['time'].gps
+        expected = LibStatus(**exp_columns)
+
+        result = self.test_session.get_lib_status(self.status_columns['time'])[0]
+
+        self.assertEqual(result, expected)
+
+        new_status_time = self.status_columns['time'] + TimeDelta(5 * 60, format='sec')
+        self.test_session.add_lib_status(new_status_time,
+                                         self.status_columns['num_files'] + 2,
+                                         self.status_columns['data_volume_gb'] + .2,
+                                         self.status_columns['free_space_gb'] - .2,
+                                         2.2, self.status_columns['num_processes'],
+                                         self.status_columns['git_version'],
+                                         self.status_columns['git_hash'])
+
+        result_mult = self.test_session.get_lib_status(self.status_columns['time'],
+                                                       stoptime=new_status_time)
+        self.assertEqual(len(result_mult), 2)
+
+        result2 = self.test_session.get_lib_status(new_status_time)[0]
+        self.assertFalse(result2 == expected)
+
+    def test_errors_lib_status(self):
+        self.assertRaises(ValueError, self.test_session.add_lib_status, 'foo',
+                          *self.status_values[1:])
+
+        self.test_session.add_lib_status(*self.status_values)
+        self.assertRaises(ValueError, self.test_session.get_lib_status, 'unhappy')
+        self.assertRaises(ValueError, self.test_session.get_lib_status,
+                          self.status_columns['time'], stoptime='unhappy')

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -7,11 +7,11 @@
 """
 import unittest
 import numpy as np
-from math import floor
 from astropy.time import Time, TimeDelta
 
 from hera_mc import mc
 from hera_mc.librarian import LibStatus, LibRAIDStatus, LibRAIDErrors, LibRemoteStatus, LibFiles
+from hera_mc import utils
 
 
 class test_hera_mc(unittest.TestCase):
@@ -43,14 +43,13 @@ class test_hera_mc(unittest.TestCase):
         self.remote_status_columns = dict(zip(self.remote_status_names,
                                               self.remote_status_values))
 
-        obsid = floor(time.gps)
+        obsid = utils.calculate_obsid(time)
         self.observation_names = ['starttime', 'stoptime', 'obsid']
         self.observation_values = [time, time + TimeDelta(10 * 60, format='sec'),
                                    obsid]
         self.observation_columns = dict(zip(self.observation_names,
                                             self.observation_values))
-        self.test_session.add_obs(*self.observation_values[0:2],
-                                  obsid=self.observation_columns['obsid'])
+        self.test_session.add_obs(*self.observation_values)
         obs_result = self.test_session.get_obs()
         self.assertTrue(len(obs_result), 1)
 

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -70,7 +70,7 @@ class test_hera_mc(unittest.TestCase):
 
         result = self.test_session.get_lib_status(self.status_columns['time'])[0]
 
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         new_status_time = self.status_columns['time'] + TimeDelta(5 * 60, format='sec')
         self.test_session.add_lib_status(new_status_time,
@@ -109,7 +109,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result), 1)
         result = result[0]
 
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         self.test_session.add_lib_raid_status(self.raid_status_values[0], 'raid_2',
                                               *self.raid_status_values[2:])
@@ -119,7 +119,7 @@ class test_hera_mc(unittest.TestCase):
                                                             TimeDelta(2 * 60, format='sec'))
         self.assertEqual(len(result_host), 1)
         result_host = result_host[0]
-        self.assertEqual(result_host, expected)
+        self.assertTrue(result_host.isclose(expected))
 
         result_mult = self.test_session.get_lib_raid_status(self.raid_status_columns['time'],
                                                             stoptime=self.raid_status_columns['time'] +
@@ -153,7 +153,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result), 1)
         result = result[0]
 
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         self.test_session.add_lib_raid_error(self.raid_error_values[0], 'raid_2',
                                              *self.raid_error_values[2:])
@@ -163,7 +163,7 @@ class test_hera_mc(unittest.TestCase):
                                                            TimeDelta(2 * 60, format='sec'))
         self.assertEqual(len(result_host), 1)
         result_host = result_host[0]
-        self.assertEqual(result_host, expected)
+        self.assertTrue(result_host.isclose(expected))
 
         result_mult = self.test_session.get_lib_raid_error(self.raid_error_columns['time'],
                                                            stoptime=self.raid_error_columns['time'] +
@@ -197,7 +197,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result), 1)
         result = result[0]
 
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         self.test_session.add_lib_remote_status(self.remote_status_values[0], 'penn',
                                                 *self.remote_status_values[2:])
@@ -208,7 +208,7 @@ class test_hera_mc(unittest.TestCase):
 
         self.assertEqual(len(result_remote), 1)
         result_remote = result_remote[0]
-        self.assertEqual(result_remote, expected)
+        self.assertTrue(result_remote.isclose(expected))
 
         result_mult = self.test_session.get_lib_remote_status(
             self.remote_status_columns['time'],
@@ -243,15 +243,16 @@ class test_hera_mc(unittest.TestCase):
         expected = LibFiles(**exp_columns)
 
         result_file = self.test_session.get_lib_files(filename=self.file_columns['filename'])[0]
-        self.assertEqual(result_file, expected)
+        self.assertTrue(result_file.isclose(expected))
 
         result = self.test_session.get_lib_files(starttime=self.file_columns['time'])
         self.assertEqual(len(result), 1)
         result = result[0]
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
+
         result_obsid = self.test_session.get_lib_files(starttime=self.file_columns['time'],
                                                        obsid=self.file_columns['obsid'])[0]
-        self.assertEqual(result_obsid, expected)
+        self.assertTrue(result_obsid.isclose(expected))
 
         new_file_time = self.file_columns['time'] + TimeDelta(3 * 60, format='sec')
         new_file = 'file2'
@@ -260,7 +261,9 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result_obsid), 2)
 
         result_all = self.test_session.get_lib_files()
-        self.assertEqual(result_obsid, result_all)
+        self.assertEqual(len(result_obsid), len(result_all))
+        for i in range(0, len(result_obsid)):
+            self.assertTrue(result_obsid[i].isclose(result_all[i]))
 
     def test_errors_add_lib_file(self):
         self.assertRaises(ValueError, self.test_session.add_lib_file,

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -73,5 +73,12 @@ class test_hera_mc(unittest.TestCase):
         result_orig = result_orig[0]
         self.assertEqual(result_orig, expected)
 
+    def test_error_obs(self):
+        t1 = Time('2016-01-10 01:15:23', scale='utc')
+        t2 = t1 + TimeDelta(120.0, format='sec')
+        self.assertRaises(ValueError, self.test_session.add_obs, 'foo', t2)
+        self.assertRaises(ValueError, self.test_session.add_obs, t1, 'foo')
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -11,7 +11,8 @@ import numpy as np
 from astropy.time import Time, TimeDelta
 from astropy.coordinates import EarthLocation
 
-from hera_mc import mc, observations
+from hera_mc import mc
+from hera_mc.observations import Observation
 
 
 class test_hera_mc(unittest.TestCase):
@@ -39,11 +40,11 @@ class test_hera_mc(unittest.TestCase):
         obsid = floor(t1.gps)
         t1.location = EarthLocation.from_geodetic(21.428249, -30.709259)
 
-        expected = [observations.Observation(obsid=obsid, start_time_jd=t1.jd,
-                                             stop_time_jd=t2.jd,
-                                             lst_start_hr=t1.sidereal_time('apparent').hour)]
+        expected = [Observation(obsid=obsid, start_time_jd=t1.jd,
+                                stop_time_jd=t2.jd,
+                                lst_start_hr=t1.sidereal_time('apparent').hour)]
 
-        self.test_session.add(observations.Observation.new_with_astropy(t1, t2))
+        self.test_session.add_obs(t1, t2)
         result = self.test_session.get_obs()
         self.assertEqual(result, expected)
 

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -81,6 +81,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertRaises(ValueError, self.test_session.add_obs, 'foo', t2, utils.calculate_obsid(t1))
         self.assertRaises(ValueError, self.test_session.add_obs, t1, 'foo', utils.calculate_obsid(t1))
         self.assertRaises(ValueError, self.test_session.add_obs, t1, t2, 'foo')
+        self.assertRaises(ValueError, utils.calculate_obsid, 'foo')
         self.assertRaises(ValueError, self.test_session.add_obs, t1, t2, utils.calculate_obsid(t1) + 2)
 
 

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -40,12 +40,14 @@ class test_hera_mc(unittest.TestCase):
         obsid = floor(t1.gps)
         t1.location = EarthLocation.from_geodetic(21.428249, -30.709259)
 
-        expected = [Observation(obsid=obsid, start_time_jd=t1.jd,
-                                stop_time_jd=t2.jd,
-                                lst_start_hr=t1.sidereal_time('apparent').hour)]
+        expected = Observation(obsid=obsid, start_time_jd=t1.jd,
+                               stop_time_jd=t2.jd,
+                               lst_start_hr=t1.sidereal_time('apparent').hour)
 
         self.test_session.add_obs(t1, t2)
         result = self.test_session.get_obs()
+        self.assertEqual(len(result), 1)
+        result = result[0]
         self.assertEqual(result, expected)
 
 

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -61,19 +61,19 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertEqual(result.length, 120.0)
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         t3 = t1 + TimeDelta(10 * 60., format='sec')
         t4 = t2 + TimeDelta(10 * 60., format='sec')
         self.test_session.add_obs(t3, t4, utils.calculate_obsid(t3))
 
-        result_mult = self.test_session.get_obs(starttime=t1, stoptime=t4)
+        result_mult = self.test_session.get_obs_by_time(t1, stoptime=t4)
         self.assertEqual(len(result_mult), 2)
 
         result_orig = self.test_session.get_obs(obsid=obsid)
         self.assertEqual(len(result_orig), 1)
         result_orig = result_orig[0]
-        self.assertEqual(result_orig, expected)
+        self.assertTrue(result_orig.isclose(expected))
 
     def test_error_obs(self):
         t1 = Time('2016-01-10 01:15:23', scale='utc')

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -8,6 +8,7 @@
 import unittest
 
 import numpy as np
+from math import floor
 from astropy.time import Time, TimeDelta
 from astropy.coordinates import EarthLocation
 
@@ -29,6 +30,17 @@ class test_hera_mc(unittest.TestCase):
         self.test_conn.close()
         self.test_db.drop_tables()
 
+    def test_new_obs(self):
+        t1 = Time('2016-01-10 01:15:23', scale='utc')
+        t2 = t1 + TimeDelta(120.0, format='sec')
+
+        t3 = t1 + TimeDelta(1e-3, format='sec')
+        t4 = t2 + TimeDelta(1e-3, format='sec')
+
+        obs1 = Observation.new_observation(t1, t2)
+        obs2 = Observation.new_observation(t3, t4)
+        self.assertFalse(obs1 == obs2)
+
     def test_add_obs(self):
         t1 = Time('2016-01-10 01:15:23', scale='utc')
         t2 = t1 + TimeDelta(120.0, format='sec')
@@ -36,9 +48,8 @@ class test_hera_mc(unittest.TestCase):
         # generated test hera_lat, hera_lon using the output of geo.py -c
         # with this website: http://www.uwgb.edu/dutchs/usefuldata/ConvertUTMNoOZ.HTM
 
-        from math import floor
         obsid = floor(t1.gps)
-        t1.location = EarthLocation.from_geodetic(21.428249, -30.709259)
+        t1.location = EarthLocation.from_geodetic(21.4283038269, -30.7215261207)
 
         expected = Observation(obsid=obsid, start_time_jd=t1.jd,
                                stop_time_jd=t2.jd,

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -20,7 +20,6 @@ class test_hera_mc(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -28,7 +27,6 @@ class test_hera_mc(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_new_obs(self):
         t1 = Time('2016-01-10 01:15:23', scale='utc')

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -50,6 +50,17 @@ class test_hera_mc(unittest.TestCase):
         result = result[0]
         self.assertEqual(result, expected)
 
+        t3 = t1 + TimeDelta(10 * 60., format='sec')
+        t4 = t2 + TimeDelta(10 * 60., format='sec')
+        self.test_session.add_obs(t3, t4)
+
+        result_mult = self.test_session.get_obs()
+        self.assertEqual(len(result_mult), 2)
+
+        result_orig = self.test_session.get_obs(obsid=obsid)
+        self.assertEqual(len(result_orig), 1)
+        result_orig = result_orig[0]
+        self.assertEqual(result_orig, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -65,7 +65,7 @@ class test_hera_mc(unittest.TestCase):
         t4 = t2 + TimeDelta(10 * 60., format='sec')
         self.test_session.add_obs(t3, t4)
 
-        result_mult = self.test_session.get_obs()
+        result_mult = self.test_session.get_obs(starttime=t1, stoptime=t4)
         self.assertEqual(len(result_mult), 2)
 
         result_orig = self.test_session.get_obs(obsid=obsid)

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -7,12 +7,12 @@
 """
 import unittest
 import numpy as np
-from math import floor
 from astropy.time import Time, TimeDelta
 from sqlalchemy.exc import NoForeignKeysError
 
 from hera_mc import mc
 from hera_mc.rtp import RTPStatus, RTPProcessEvent, RTPProcessRecord
+from hera_mc import utils
 
 
 class test_hera_mc(unittest.TestCase):
@@ -24,14 +24,13 @@ class test_hera_mc(unittest.TestCase):
         self.test_session = mc.MCSession(bind=self.test_conn)
 
         time = Time.now()
-        obsid = floor(time.gps)
+        obsid = utils.calculate_obsid(time)
         self.observation_names = ['starttime', 'stoptime', 'obsid']
         self.observation_values = [time, time + TimeDelta(10 * 60, format='sec'),
                                    obsid]
         self.observation_columns = dict(zip(self.observation_names,
                                             self.observation_values))
-        self.test_session.add_obs(*self.observation_values[0:2],
-                                  obsid=self.observation_columns['obsid'])
+        self.test_session.add_obs(*self.observation_values)
         obs_result = self.test_session.get_obs()
         self.assertTrue(len(obs_result), 1)
 
@@ -106,10 +105,10 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(result, expected)
 
         new_obsid_time = self.event_columns['time'] + TimeDelta(3 * 60, format='sec')
-        new_obsid = self.event_columns['obsid'] + 10
+        new_obsid = utils.calculate_obsid(new_obsid_time)
         self.test_session.add_obs(Time(new_obsid_time),
                                   Time(new_obsid_time + TimeDelta(10 * 60, format='sec')),
-                                  obsid=new_obsid)
+                                  new_obsid)
         obs_result = self.test_session.get_obs(obsid=new_obsid)
         self.assertEqual(obs_result[0].obsid, new_obsid)
 
@@ -184,10 +183,10 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(result_obsid, expected)
 
         new_obsid_time = self.record_columns['time'] + TimeDelta(3 * 60, format='sec')
-        new_obsid = self.record_columns['obsid'] + 10
+        new_obsid = utils.calculate_obsid(new_obsid_time)
         self.test_session.add_obs(Time(new_obsid_time),
                                   Time(new_obsid_time + TimeDelta(10 * 60, format='sec')),
-                                  obsid=new_obsid)
+                                  new_obsid)
         obs_result = self.test_session.get_obs(obsid=new_obsid)
         self.assertEqual(obs_result[0].obsid, new_obsid)
 

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -151,6 +151,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertRaises(ValueError, self.test_session.get_rtp_process_event,
                           self.event_columns['time'], stoptime='bar')
 
+        # raise error if pass value not in enum
         # self.assertRaises(ValueError, self.test_session.add_rtp_process_event,
         #                   self.event_columns['time'], self.event_columns['obsid'],
         #                   'foo')

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -144,7 +144,7 @@ class test_hera_mc(unittest.TestCase):
 
     def test_errors_rtp_process_event(self):
         self.assertRaises(ValueError, self.test_session.add_rtp_process_event, 'foo',
-                          *self.status_values[1:])
+                          *self.event_values[1:])
 
         self.test_session.add_rtp_process_event(*self.event_values)
         self.assertRaises(ValueError, self.test_session.get_rtp_process_event, 'foo')

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -1,0 +1,65 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Testing for `hera_mc.rtp`.
+
+"""
+import unittest
+
+import numpy as np
+import datetime
+import pytz
+
+from hera_mc import mc
+from hera_mc.rtp import RTPStatus
+
+
+class test_hera_mc(unittest.TestCase):
+
+    def setUp(self):
+        self.test_db = mc.connect_to_mc_testing_db()
+        self.test_db.create_tables()
+        self.test_conn = self.test_db.engine.connect()
+        self.test_trans = self.test_conn.begin()
+        self.test_session = mc.MCSession(bind=self.test_conn)
+
+    def tearDown(self):
+        self.test_trans.rollback()
+        self.test_conn.close()
+        self.test_db.drop_tables()
+
+    def test_add_rtp_status(self):
+        status_time = pytz.utc.localize(datetime.datetime.utcnow())
+        status = 'happy'
+        event_min_elapsed = 3.6
+        num_processes = 8
+        restart_hours_elapsed = 10.2
+
+        expected = RTPStatus(time=status_time, status=status,
+                             event_min_elapsed=event_min_elapsed,
+                             num_processes=num_processes,
+                             restart_hours_elapsed=restart_hours_elapsed)
+
+        self.test_session.add_rtp_status(status_time, status, event_min_elapsed,
+                                         num_processes, restart_hours_elapsed)
+        result = self.test_session.get_rtp_status(status_time)[0]
+
+        self.assertEqual(result, expected)
+
+        new_status_time = status_time + datetime.timedelta(minutes=5)
+        new_status = 'unhappy'
+        self.test_session.add_rtp_status(new_status_time, new_status,
+                                         event_min_elapsed + 5, num_processes,
+                                         restart_hours_elapsed + 5. / 60.)
+
+        result_mult = self.test_session.get_rtp_status(status_time,
+                                                       stoptime=new_status_time)
+        self.assertEqual(len(result_mult), 2)
+
+        result2 = self.test_session.get_rtp_status(new_status_time)[0]
+        self.assertFalse(result2 == expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -60,7 +60,7 @@ class test_hera_mc(unittest.TestCase):
 
         result = self.test_session.get_rtp_status(self.status_columns['time'])[0]
 
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         new_status_time = self.status_columns['time'] + TimeDelta(5 * 60, format='sec')
         new_status = 'unhappy'
@@ -102,7 +102,7 @@ class test_hera_mc(unittest.TestCase):
         result = result[0]
         result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
                                                                obsid=self.event_columns['obsid'])[0]
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         new_obsid_time = self.event_columns['time'] + TimeDelta(3 * 60, format='sec')
         new_obsid = utils.calculate_obsid(new_obsid_time)
@@ -117,7 +117,7 @@ class test_hera_mc(unittest.TestCase):
                                                 self.event_columns['event'])
         result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
                                                                obsid=self.event_columns['obsid'])[0]
-        self.assertEqual(result_obsid, expected)
+        self.assertTrue(result_obsid.isclose(expected))
 
         new_event_time = self.event_columns['time'] + TimeDelta(5 * 60, format='sec')
         new_event = 'started'
@@ -176,11 +176,11 @@ class test_hera_mc(unittest.TestCase):
         result = self.test_session.get_rtp_process_record(self.record_columns['time'])
         self.assertEqual(len(result), 1)
         result = result[0]
-        self.assertEqual(result, expected)
+        self.assertTrue(result.isclose(expected))
 
         result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
                                                                 obsid=self.record_columns['obsid'])[0]
-        self.assertEqual(result_obsid, expected)
+        self.assertTrue(result_obsid.isclose(expected))
 
         new_obsid_time = self.record_columns['time'] + TimeDelta(3 * 60, format='sec')
         new_obsid = utils.calculate_obsid(new_obsid_time)
@@ -195,7 +195,7 @@ class test_hera_mc(unittest.TestCase):
                                                  *self.record_values[2:5])
         result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
                                                                 obsid=self.record_columns['obsid'])[0]
-        self.assertEqual(result_obsid, expected)
+        self.assertTrue(result_obsid.isclose(expected))
 
         new_record_time = self.record_columns['time'] + TimeDelta(5 * 60, format='sec')
         new_pipeline = 'new_pipe'

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -19,7 +19,6 @@ class test_hera_mc(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -52,7 +51,6 @@ class test_hera_mc(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_add_rtp_status(self):
         self.test_session.add_rtp_status(*self.status_values)
@@ -166,7 +164,7 @@ class test_hera_mc(unittest.TestCase):
 
     def test_add_rtp_process_record(self):
         # raise error if try to add process event with unmatched obsid
-        # self.assertRaises(NoForeignKeysError, self.test_session.add_rtp_process_event,
+        # self.assertRaises(NoForeignKeysError, self.test_session.add_rtp_process_record,
         #                   self.record_values[0], self.record_values[1] + 2,
         #                   self.record_values[2:5])
 
@@ -179,9 +177,11 @@ class test_hera_mc(unittest.TestCase):
         result = self.test_session.get_rtp_process_record(self.record_columns['time'])
         self.assertEqual(len(result), 1)
         result = result[0]
+        self.assertEqual(result, expected)
+
         result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
                                                                 obsid=self.record_columns['obsid'])[0]
-        self.assertEqual(result, expected)
+        self.assertEqual(result_obsid, expected)
 
         new_obsid_time = self.record_columns['time'] + TimeDelta(3 * 60, format='sec')
         new_obsid = self.record_columns['obsid'] + 10

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -6,13 +6,13 @@
 
 """
 import unittest
-
 import numpy as np
-import datetime
-import pytz
+from math import floor
+from astropy.time import Time, TimeDelta
+from sqlalchemy.exc import NoForeignKeysError
 
 from hera_mc import mc
-from hera_mc.rtp import RTPStatus
+from hera_mc.rtp import RTPStatus, RTPProcessEvent, RTPProcessRecord
 
 
 class test_hera_mc(unittest.TestCase):
@@ -23,12 +23,31 @@ class test_hera_mc(unittest.TestCase):
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
-        self.column_names = ['time', 'status', 'event_min_elapsed',
+
+        time = Time.now()
+        obsid = floor(time.gps)
+        self.observation_names = ['starttime', 'stoptime', 'obsid']
+        self.observation_values = [time, time + TimeDelta(10 * 60, format='sec'),
+                                   obsid]
+        self.observation_columns = dict(zip(self.observation_names,
+                                            self.observation_values))
+        self.test_session.add_obs(*self.observation_values[0:2],
+                                  obsid=self.observation_columns['obsid'])
+        obs_result = self.test_session.get_obs()
+        self.assertTrue(len(obs_result), 1)
+
+        self.status_names = ['time', 'status', 'event_min_elapsed',
                              'num_processes', 'restart_hours_elapsed']
-        self.column_values = [pytz.utc.localize(datetime.datetime.utcnow()),
-                              'happy', 3.6, 8, 10.2]
-        self.columns = dict(zip(self.column_names, self.column_values))
-        self.test_session.add_rtp_status(*self.column_values)
+        self.status_values = [time, 'happy', 3.6, 8, 10.2]
+        self.status_columns = dict(zip(self.status_names, self.status_values))
+
+        self.event_names = ['time', 'obsid', 'event']
+        self.event_values = [time, obsid, 'queued']
+        self.event_columns = dict(zip(self.event_names, self.event_values))
+
+        self.record_names = ['time', 'obsid', 'pipeline_list', 'git_version', 'git_hash']
+        self.record_values = [time, obsid, 'sample_pipe', 'v0.0.1', 'lskdjf24l']
+        self.record_columns = dict(zip(self.record_names, self.record_values))
 
     def tearDown(self):
         self.test_trans.rollback()
@@ -36,30 +55,176 @@ class test_hera_mc(unittest.TestCase):
         self.test_db.drop_tables()
 
     def test_add_rtp_status(self):
-        expected = RTPStatus(**self.columns)
+        self.test_session.add_rtp_status(*self.status_values)
 
-        result = self.test_session.get_rtp_status(self.columns['time'])[0]
+        exp_columns = self.status_columns.copy()
+        exp_columns['time'] = exp_columns['time'].gps
+        expected = RTPStatus(**exp_columns)
+
+        result = self.test_session.get_rtp_status(self.status_columns['time'])[0]
 
         self.assertEqual(result, expected)
 
-        new_status_time = self.columns['time'] + datetime.timedelta(minutes=5)
+        new_status_time = self.status_columns['time'] + TimeDelta(5 * 60, format='sec')
         new_status = 'unhappy'
         self.test_session.add_rtp_status(new_status_time, new_status,
-                                         self.columns['event_min_elapsed'] + 5,
-                                         self.columns['num_processes'],
-                                         self.columns['restart_hours_elapsed'] + 5. / 60.)
+                                         self.status_columns['event_min_elapsed'] + 5,
+                                         self.status_columns['num_processes'],
+                                         self.status_columns['restart_hours_elapsed'] + 5. / 60.)
 
-        result_mult = self.test_session.get_rtp_status(self.columns['time'],
+        result_mult = self.test_session.get_rtp_status(self.status_columns['time'],
                                                        stoptime=new_status_time)
         self.assertEqual(len(result_mult), 2)
 
         result2 = self.test_session.get_rtp_status(new_status_time)[0]
         self.assertFalse(result2 == expected)
 
-    def test_errors_server_status(self):
+    def test_errors_rtp_status(self):
+        self.assertRaises(ValueError, self.test_session.add_rtp_status, 'foo',
+                          *self.status_values[1:])
+
+        self.test_session.add_rtp_status(*self.status_values)
         self.assertRaises(ValueError, self.test_session.get_rtp_status, 'unhappy')
         self.assertRaises(ValueError, self.test_session.get_rtp_status,
-                          self.columns['time'], stoptime='unhappy')
+                          self.status_columns['time'], stoptime='unhappy')
+
+    def test_add_rtp_process_event(self):
+        # raise error if try to add process event with unmatched obsid
+        # self.assertRaises(NoForeignKeysError, self.test_session.add_rtp_process_event,
+        #                   self.event_values[0], self.event_values[1] + 2,
+        #                   self.event_values[2])
+
+        self.test_session.add_rtp_process_event(*self.event_values)
+
+        exp_columns = self.event_columns.copy()
+        exp_columns['time'] = exp_columns['time'].gps
+        expected = RTPProcessEvent(**exp_columns)
+
+        result = self.test_session.get_rtp_process_event(self.event_columns['time'])
+        self.assertEqual(len(result), 1)
+        result = result[0]
+        result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
+                                                               obsid=self.event_columns['obsid'])[0]
+        self.assertEqual(result, expected)
+
+        new_obsid_time = self.event_columns['time'] + TimeDelta(3 * 60, format='sec')
+        new_obsid = self.event_columns['obsid'] + 10
+        self.test_session.add_obs(Time(new_obsid_time),
+                                  Time(new_obsid_time + TimeDelta(10 * 60, format='sec')),
+                                  obsid=new_obsid)
+        obs_result = self.test_session.get_obs(obsid=new_obsid)
+        self.assertEqual(obs_result[0].obsid, new_obsid)
+
+        self.test_session.add_rtp_process_event(new_obsid_time,
+                                                new_obsid,
+                                                self.event_columns['event'])
+        result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
+                                                               obsid=self.event_columns['obsid'])[0]
+        self.assertEqual(result_obsid, expected)
+
+        new_event_time = self.event_columns['time'] + TimeDelta(5 * 60, format='sec')
+        new_event = 'started'
+        self.test_session.add_rtp_process_event(new_event_time,
+                                                self.event_columns['obsid'],
+                                                new_event)
+
+        result_mult = self.test_session.get_rtp_process_event(self.event_columns['time'],
+                                                              stoptime=new_event_time)
+        self.assertEqual(len(result_mult), 3)
+
+        result_mult_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
+                                                                    stoptime=new_event_time,
+                                                                    obsid=self.event_columns['obsid'])
+        self.assertEqual(len(result_mult_obsid), 2)
+
+        result_new_obsid = self.test_session.get_rtp_process_event(self.event_columns['time'],
+                                                                   obsid=new_obsid)[0]
+
+        self.assertFalse(result_new_obsid == expected)
+
+    def test_errors_rtp_process_event(self):
+        self.assertRaises(ValueError, self.test_session.add_rtp_process_event, 'foo',
+                          *self.status_values[1:])
+
+        self.test_session.add_rtp_process_event(*self.event_values)
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_event, 'foo')
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_event,
+                          self.event_columns['time'], stoptime='bar')
+
+        # self.assertRaises(ValueError, self.test_session.add_rtp_process_event,
+        #                   self.event_columns['time'], self.event_columns['obsid'],
+        #                   'foo')
+
+    def test_classes_not_equal(self):
+        self.test_session.add_rtp_process_event(*self.event_values)
+        self.test_session.add_rtp_status(*self.status_values)
+
+        status_result = self.test_session.get_rtp_status(self.status_columns['time'])[0]
+        event_result = self.test_session.get_rtp_process_event(self.event_columns['time'])
+        self.assertFalse(status_result == event_result)
+
+    def test_add_rtp_process_record(self):
+        # raise error if try to add process event with unmatched obsid
+        # self.assertRaises(NoForeignKeysError, self.test_session.add_rtp_process_event,
+        #                   self.record_values[0], self.record_values[1] + 2,
+        #                   self.record_values[2:5])
+
+        self.test_session.add_rtp_process_record(*self.record_values)
+
+        exp_columns = self.record_columns.copy()
+        exp_columns['time'] = exp_columns['time'].gps
+        expected = RTPProcessRecord(**exp_columns)
+
+        result = self.test_session.get_rtp_process_record(self.record_columns['time'])
+        self.assertEqual(len(result), 1)
+        result = result[0]
+        result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
+                                                                obsid=self.record_columns['obsid'])[0]
+        self.assertEqual(result, expected)
+
+        new_obsid_time = self.record_columns['time'] + TimeDelta(3 * 60, format='sec')
+        new_obsid = self.record_columns['obsid'] + 10
+        self.test_session.add_obs(Time(new_obsid_time),
+                                  Time(new_obsid_time + TimeDelta(10 * 60, format='sec')),
+                                  obsid=new_obsid)
+        obs_result = self.test_session.get_obs(obsid=new_obsid)
+        self.assertEqual(obs_result[0].obsid, new_obsid)
+
+        self.test_session.add_rtp_process_record(new_obsid_time,
+                                                 new_obsid,
+                                                 *self.record_values[2:5])
+        result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
+                                                                obsid=self.record_columns['obsid'])[0]
+        self.assertEqual(result_obsid, expected)
+
+        new_record_time = self.record_columns['time'] + TimeDelta(5 * 60, format='sec')
+        new_pipeline = 'new_pipe'
+        self.test_session.add_rtp_process_record(new_record_time,
+                                                 self.record_columns['obsid'],
+                                                 new_pipeline, *self.record_values[3:5])
+
+        result_mult = self.test_session.get_rtp_process_record(self.record_columns['time'],
+                                                               stoptime=new_record_time)
+        self.assertEqual(len(result_mult), 3)
+
+        result_mult_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
+                                                                     stoptime=new_record_time,
+                                                                     obsid=self.record_columns['obsid'])
+        self.assertEqual(len(result_mult_obsid), 2)
+
+        result_new_obsid = self.test_session.get_rtp_process_record(self.record_columns['time'],
+                                                                    obsid=new_obsid)[0]
+
+        self.assertFalse(result_new_obsid == expected)
+
+    def test_errors_rtp_process_record(self):
+        self.assertRaises(ValueError, self.test_session.add_rtp_process_record, 'foo',
+                          *self.status_values[1:])
+
+        self.test_session.add_rtp_process_record(*self.record_values)
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_record, 'foo')
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_record,
+                          self.record_columns['time'], stoptime='bar')
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -49,7 +49,6 @@ class test_hera_mc(unittest.TestCase):
                                 memory_size_gb=memory_size_gb, disk_space_pct=disk_space_pct,
                                 disk_size_gb=disk_size_gb,
                                 network_bandwidth_mbs=network_bandwidth_mbs)
-        print(expected)
         self.test_session.add_server_status(hostname, ip_address, server_time, num_cores,
                                             cpu_load_pct, uptime_days, memory_used_pct,
                                             memory_size_gb, disk_space_pct, disk_size_gb,
@@ -59,13 +58,15 @@ class test_hera_mc(unittest.TestCase):
         # check that the mc_times are very close
         mc_time_diff = abs(expected.mc_time.astimezone(pytz.utc) - result.mc_time.astimezone(pytz.utc))
         self.assertTrue(mc_time_diff < datetime.timedelta(seconds=0.01))
+        if mc_time_diff > datetime.timedelta(seconds=0):
+            self.assertNotEqual(result, expected)
 
         # they are close enough. set them equal to test the rest of the objects
         expected.mc_time = result.mc_time.astimezone(pytz.utc)
 
         self.assertEqual(result, expected)
 
-        self.test_session.add_server_status('test_host2', ip_address, server_time, num_cores,
+        self.test_session.add_server_status('test_host2', ip_address, server_time, num_cores - 2,
                                             cpu_load_pct, uptime_days, memory_used_pct,
                                             memory_size_gb, disk_space_pct, disk_size_gb,
                                             network_bandwidth_mbs=network_bandwidth_mbs)
@@ -82,7 +83,7 @@ class test_hera_mc(unittest.TestCase):
         self.assertEqual(len(result_mult), 2)
 
         result2 = self.test_session.get_server_status(server_time, hostname='test_host2')[0]
-        # mc_times will be different. set them equal so that doesn't control the test
+        # mc_times will be different, so won't match. set them equal so that we can test the rest
         expected.mc_time = result2.mc_time.astimezone(pytz.utc)
         self.assertNotEqual(result2, expected)
 

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -115,6 +115,12 @@ class test_hera_mc(unittest.TestCase):
             self.assertRaises(ValueError, self.test_session.get_server_status,
                               sub, self.columns['system_time'], stoptime='test_host')
 
+        self.assertRaises(ValueError, self.test_session.add_server_status, 'foo',
+                          self.column_values[0], *self.column_values[2:11],
+                          network_bandwidth_mbs=self.column_values[11])
+        self.assertRaises(ValueError, self.test_session.get_server_status, 'foo',
+                          self.column_values[1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -8,10 +8,10 @@
 import unittest
 
 import numpy as np
-from astropy.time import Time, TimeDelta
-from astropy.coordinates import EarthLocation
+import datetime
 
-from hera_mc import mc, server_status
+from hera_mc import mc
+from hera_mc.server_status import ServerStatus
 
 
 class test_hera_mc(unittest.TestCase):
@@ -28,25 +28,36 @@ class test_hera_mc(unittest.TestCase):
         self.test_conn.close()
         self.test_db.drop_tables()
 
-    # def test_add_obs(self):
-    #     t1 = Time('2016-01-10 01:15:23', scale='utc')
-    #     t2 = t1 + TimeDelta(120.0, format='sec')
-    #
-    #     # generated test hera_lat, hera_lon using the output of geo.py -c
-    #     # with this website: http://www.uwgb.edu/dutchs/usefuldata/ConvertUTMNoOZ.HTM
-    #
-    #     from math import floor
-    #     obsid = floor(t1.gps)
-    #     t1.location = EarthLocation.from_geodetic(21.428249, -30.709259)
-    #
-    #     expected = [observations.Observation(obsid=obsid, start_time_jd=t1.jd,
-    #                                          stop_time_jd=t2.jd,
-    #                                          lst_start_hr=t1.sidereal_time('apparent').hour)]
-    #
-    #     self.test_session.add(observations.Observation.new_with_astropy(t1, t2))
-    #     result = self.test_session.get_obs()
-    #     self.assertEqual(result, expected)
+    def test_add_server_status(self):
+        hostname = 'test_host'
+        ip_address = '0.0.0.0'
+        server_time = datetime.datetime.now()
+        num_cores = 16
+        cpu_load_pct = 20.5
+        uptime_days = 31.4
+        memory_used_pct = 43.2
+        memory_size_gb = 32.
+        disk_space_pct = 46.8
+        disk_size_gb = 510.4
+        network_bandwidth_mbs = 10.4
 
+        expected = [ServerStatus(hostname=hostname, mc_time=datetime.datetime.now(),
+                                 ip_address=ip_address, system_time=server_time,
+                                 num_cores=num_cores, cpu_load_pct=cpu_load_pct,
+                                 uptime_days=uptime_days, memory_used_pct=memory_used_pct,
+                                 memory_size_gb=memory_size_gb, disk_space_pct=disk_space_pct,
+                                 disk_size_gb=disk_size_gb, network_bandwidth_mbs=network_bandwidth_mbs)]
+
+        self.test_session.add_server_status(hostname, ip_address, server_time, num_cores,
+                                            cpu_load_pct, uptime_days, memory_used_pct, memory_size_gb,
+                                            disk_space_pct, disk_size_gb,
+                                            network_bandwidth_mbs=network_bandwidth_mbs)
+        result = self.test_session.get_server_status(server_time - datetime.timedelta(minutes=15))
+        result_host = self.test_session.get_server_status(server_time - datetime.timedelta(minutes=15),
+                                                          hostname=hostname)
+
+        self.assertEqual(result, expected)
+        self.assertEqual(result_host, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -42,27 +42,28 @@ class test_hera_mc(unittest.TestCase):
         disk_size_gb = 510.4
         network_bandwidth_mbs = 10.4
 
-        expected = [ServerStatus(hostname=hostname, mc_time=pytz.utc.localize(datetime.datetime.utcnow()),
-                                 ip_address=ip_address, system_time=server_time,
-                                 num_cores=num_cores, cpu_load_pct=cpu_load_pct,
-                                 uptime_days=uptime_days, memory_used_pct=memory_used_pct,
-                                 memory_size_gb=memory_size_gb, disk_space_pct=disk_space_pct,
-                                 disk_size_gb=disk_size_gb,
-                                 network_bandwidth_mbs=network_bandwidth_mbs)]
+        expected = ServerStatus(hostname=hostname, mc_time=pytz.utc.localize(datetime.datetime.utcnow()),
+                                ip_address=ip_address, system_time=server_time,
+                                num_cores=num_cores, cpu_load_pct=cpu_load_pct,
+                                uptime_days=uptime_days, memory_used_pct=memory_used_pct,
+                                memory_size_gb=memory_size_gb, disk_space_pct=disk_space_pct,
+                                disk_size_gb=disk_size_gb,
+                                network_bandwidth_mbs=network_bandwidth_mbs)
+        print(expected)
         self.test_session.add_server_status(hostname, ip_address, server_time, num_cores,
                                             cpu_load_pct, uptime_days, memory_used_pct,
                                             memory_size_gb, disk_space_pct, disk_size_gb,
                                             network_bandwidth_mbs=network_bandwidth_mbs)
-        result = self.test_session.get_server_status(server_time)
+        result = self.test_session.get_server_status(server_time)[0]
 
         # check that the mc_times are very close
-        mc_time_diff = abs(expected[0].mc_time.astimezone(pytz.utc) - result[0].mc_time.astimezone(pytz.utc))
+        mc_time_diff = abs(expected.mc_time.astimezone(pytz.utc) - result.mc_time.astimezone(pytz.utc))
         self.assertTrue(mc_time_diff < datetime.timedelta(seconds=0.01))
 
         # they are close enough. set them equal to test the rest of the objects
-        expected[0].mc_time = result[0].mc_time.astimezone(pytz.utc)
+        expected.mc_time = result.mc_time.astimezone(pytz.utc)
 
-        self.assertEqual(result[0], expected[0])
+        self.assertEqual(result, expected)
 
         self.test_session.add_server_status('test_host2', ip_address, server_time, num_cores,
                                             cpu_load_pct, uptime_days, memory_used_pct,
@@ -71,8 +72,8 @@ class test_hera_mc(unittest.TestCase):
 
         result_host = self.test_session.get_server_status(server_time, hostname=hostname,
                                                           stoptime=server_time + datetime.timedelta(minutes=2))
-
-        self.assertEqual(result, expected)
+        self.assertEqual(len(result_host), 1)
+        result_host = result_host[0]
         self.assertEqual(result_host, expected)
 
         result_mult = self.test_session.get_server_status(server_time,
@@ -80,9 +81,9 @@ class test_hera_mc(unittest.TestCase):
 
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_server_status(server_time, hostname='test_host2')
+        result2 = self.test_session.get_server_status(server_time, hostname='test_host2')[0]
         # mc_times will be different. set them equal so that doesn't control the test
-        expected[0].mc_time = result2[0].mc_time.astimezone(pytz.utc)
+        expected.mc_time = result2.mc_time.astimezone(pytz.utc)
         self.assertNotEqual(result2, expected)
 
 

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -29,6 +29,26 @@ class test_hera_mc(unittest.TestCase):
         self.test_conn.close()
         self.test_db.drop_tables()
 
+    def test_repr(self):
+        columns = {'hostname': 'test_host',
+                   'mc_time': pytz.utc.localize(datetime.datetime.utcnow()),
+                   'ip_address': '0.0.0.0',
+                   'system_time': pytz.utc.localize(datetime.datetime.utcnow()),
+                   'num_cores': 16,
+                   'cpu_load_pct': 20.5,
+                   'uptime_days': 31.4,
+                   'memory_used_pct': 43.2,
+                   'memory_size_gb': 32.,
+                   'disk_space_pct': 46.8,
+                   'disk_size_gb': 510.4,
+                   'network_bandwidth_mbs': 10.4}
+
+        servstat = ServerStatus(**columns)
+
+        rep_string = ('<ServerStatus(test_host, ' + str(columns['mc_time']) + ', 0.0.0.0, ' +
+                      str(columns['system_time']) + ', 16, 20.5, 31.4, 43.2, 32.0, 46.8, 510.4, 10.4)>')
+        self.assertEqual(str(servstat), rep_string)
+
     def test_add_server_status(self):
         hostname = 'test_host'
         ip_address = '0.0.0.0'
@@ -59,7 +79,7 @@ class test_hera_mc(unittest.TestCase):
         mc_time_diff = abs(expected.mc_time.astimezone(pytz.utc) - result.mc_time.astimezone(pytz.utc))
         self.assertTrue(mc_time_diff < datetime.timedelta(seconds=0.01))
         if mc_time_diff > datetime.timedelta(seconds=0):
-            self.assertNotEqual(result, expected)
+            self.assertFalse(result == expected)
 
         # they are close enough. set them equal to test the rest of the objects
         expected.mc_time = result.mc_time.astimezone(pytz.utc)
@@ -85,7 +105,7 @@ class test_hera_mc(unittest.TestCase):
         result2 = self.test_session.get_server_status(server_time, hostname='test_host2')[0]
         # mc_times will be different, so won't match. set them equal so that we can test the rest
         expected.mc_time = result2.mc_time.astimezone(pytz.utc)
-        self.assertNotEqual(result2, expected)
+        self.assertFalse(result2 == expected)
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -115,5 +115,6 @@ class test_hera_mc(unittest.TestCase):
             self.assertRaises(ValueError, self.test_session.get_server_status,
                               sub, self.columns['system_time'], stoptime='test_host')
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -74,6 +74,14 @@ class test_hera_mc(unittest.TestCase):
             self.assertEqual(len(result), 1)
             result = result[0]
 
+            # mc_system_timediff may not be identical. Check that they are close
+            # and set them equal so the rest of the object can be tested
+            mc_system_timediff_diff = (abs(result.mc_system_timediff -
+                                       expected.mc_system_timediff))
+            self.assertTrue(mc_system_timediff_diff < 0.01)
+            if mc_system_timediff_diff > 0.001:
+                expected.mc_system_timediff = result.mc_system_timediff
+
             self.assertTrue(result.isclose(expected))
 
             self.test_session.add_server_status(sub, 'test_host2', *self.column_values[2:11],
@@ -114,6 +122,15 @@ class test_hera_mc(unittest.TestCase):
             self.assertRaises(ValueError, self.test_session.get_server_status, sub, 'test_host')
             self.assertRaises(ValueError, self.test_session.get_server_status,
                               sub, self.columns['system_time'], stoptime='test_host')
+
+            if sub == 'rtp':
+                self.assertRaises(ValueError, RTPServerStatus.create, 'foo',
+                                  self.column_values[0], *self.column_values[2:11],
+                                  network_bandwidth_mbs=self.column_values[11])
+            elif sub == 'lib':
+                self.assertRaises(ValueError, LibServerStatus.create, 'foo',
+                                  self.column_values[0], *self.column_values[2:11],
+                                  network_bandwidth_mbs=self.column_values[11])
 
         self.assertRaises(ValueError, self.test_session.add_server_status, 'foo',
                           self.column_values[0], *self.column_values[2:11],

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -77,7 +77,7 @@ class test_hera_mc(unittest.TestCase):
             # they are close enough. set them equal to test the rest of the objects
             expected.mc_time = result.mc_time
 
-            self.assertEqual(result, expected)
+            self.assertTrue(result.isclose(expected))
 
             self.test_session.add_server_status(sub, 'test_host2', *self.column_values[2:11],
                                                 network_bandwidth_mbs=self.column_values[11])
@@ -87,7 +87,7 @@ class test_hera_mc(unittest.TestCase):
                                                               TimeDelta(2 * 60, format='sec'))
             self.assertEqual(len(result_host), 1)
             result_host = result_host[0]
-            self.assertEqual(result_host, expected)
+            self.assertTrue(result_host.isclose(expected))
 
             result_mult = self.test_session.get_server_status(sub, self.columns['system_time'],
                                                               stoptime=self.columns['system_time'] +

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -1,0 +1,52 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Testing for `hera_mc.server_status`.
+
+"""
+import unittest
+
+import numpy as np
+from astropy.time import Time, TimeDelta
+from astropy.coordinates import EarthLocation
+
+from hera_mc import mc, server_status
+
+
+class test_hera_mc(unittest.TestCase):
+
+    def setUp(self):
+        self.test_db = mc.connect_to_mc_testing_db()
+        self.test_db.create_tables()
+        self.test_conn = self.test_db.engine.connect()
+        self.test_trans = self.test_conn.begin()
+        self.test_session = mc.MCSession(bind=self.test_conn)
+
+    def tearDown(self):
+        self.test_trans.rollback()
+        self.test_conn.close()
+        self.test_db.drop_tables()
+
+    # def test_add_obs(self):
+    #     t1 = Time('2016-01-10 01:15:23', scale='utc')
+    #     t2 = t1 + TimeDelta(120.0, format='sec')
+    #
+    #     # generated test hera_lat, hera_lon using the output of geo.py -c
+    #     # with this website: http://www.uwgb.edu/dutchs/usefuldata/ConvertUTMNoOZ.HTM
+    #
+    #     from math import floor
+    #     obsid = floor(t1.gps)
+    #     t1.location = EarthLocation.from_geodetic(21.428249, -30.709259)
+    #
+    #     expected = [observations.Observation(obsid=obsid, start_time_jd=t1.jd,
+    #                                          stop_time_jd=t2.jd,
+    #                                          lst_start_hr=t1.sidereal_time('apparent').hour)]
+    #
+    #     self.test_session.add(observations.Observation.new_with_astropy(t1, t2))
+    #     result = self.test_session.get_obs()
+    #     self.assertEqual(result, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -87,6 +87,11 @@ class test_hera_mc(unittest.TestCase):
         self.assertFalse(result2 == expected)
 
     def test_errors_server_status(self):
+        self.assertRaises(ValueError, self.test_session.add_server_status,
+                          self.column_values[0], self.column_values[2],
+                          'foo', *self.column_values[4:11],
+                          network_bandwidth_mbs=self.column_values[11])
+
         self.test_session.add_server_status(self.column_values[0], *self.column_values[2:11],
                                             network_bandwidth_mbs=self.column_values[11])
         self.assertRaises(ValueError, self.test_session.get_server_status, 'test_host')

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -17,7 +17,6 @@ class test_hera_mc(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -33,7 +32,6 @@ class test_hera_mc(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_repr(self):
         servstat = ServerStatus(**self.columns)

--- a/hera_mc/tests/test_temperatures.py
+++ b/hera_mc/tests/test_temperatures.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 
 import unittest
 
+from math import floor
 import numpy as np
 from astropy.time import Time, TimeDelta
 from hera_mc import mc, temperatures
@@ -50,7 +51,7 @@ class test_temperatures(unittest.TestCase):
         self.test_session.add_paper_temps(t1, temp_list)
         self.test_session.add_paper_temps(t2, temp2_list)
 
-        expected = [temperatures.PaperTemperatures(gps_time=t1.gps, jd_time=t1.jd, **temp_dict)]
+        expected = [temperatures.PaperTemperatures(time=int(floor(t1.gps)), **temp_dict)]
         result = self.test_session.get_paper_temps(t1 - TimeDelta(3.0, format='sec'))
         self.assertEqual(len(result), len(expected))
         for i in range(0, len(result)):
@@ -59,9 +60,9 @@ class test_temperatures(unittest.TestCase):
         result = self.test_session.get_paper_temps(t1 + TimeDelta(200.0, format='sec'))
         self.assertEqual(result, [])
 
-        expected2 = [temperatures.PaperTemperatures(gps_time=t1.gps, jd_time=t1.jd,
+        expected2 = [temperatures.PaperTemperatures(time=int(floor(t1.gps)),
                                                     **temp_dict),
-                     temperatures.PaperTemperatures(gps_time=t2.gps, jd_time=t2.jd,
+                     temperatures.PaperTemperatures(time=int(floor(t2.gps)),
                                                     **temp2_dict)]
         result = self.test_session.get_paper_temps(t1 - TimeDelta(3.0, format='sec'),
                                                    stoptime=t2 + TimeDelta(1.0, format='sec'))

--- a/hera_mc/tests/test_temperatures.py
+++ b/hera_mc/tests/test_temperatures.py
@@ -52,7 +52,9 @@ class test_temperatures(unittest.TestCase):
 
         expected = [temperatures.PaperTemperatures(gps_time=t1.gps, jd_time=t1.jd, **temp_dict)]
         result = self.test_session.get_paper_temps(t1 - TimeDelta(3.0, format='sec'))
-        self.assertEqual(result, expected)
+        self.assertEqual(len(result), len(expected))
+        for i in range(0, len(result)):
+            self.assertTrue(result[i].isclose(expected[i]))
 
         result = self.test_session.get_paper_temps(t1 + TimeDelta(200.0, format='sec'))
         self.assertEqual(result, [])
@@ -63,7 +65,9 @@ class test_temperatures(unittest.TestCase):
                                                     **temp2_dict)]
         result = self.test_session.get_paper_temps(t1 - TimeDelta(3.0, format='sec'),
                                                    stoptime=t2 + TimeDelta(1.0, format='sec'))
-        self.assertEqual(result, expected2)
+        self.assertEqual(len(result), len(expected2))
+        for i in range(0, len(result)):
+            self.assertTrue(result[i].isclose(expected2[i]))
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_temperatures.py
+++ b/hera_mc/tests/test_temperatures.py
@@ -18,7 +18,6 @@ class test_temperatures(unittest.TestCase):
 
     def setUp(self):
         self.test_db = mc.connect_to_mc_testing_db()
-        self.test_db.create_tables()
         self.test_conn = self.test_db.engine.connect()
         self.test_trans = self.test_conn.begin()
         self.test_session = mc.MCSession(bind=self.test_conn)
@@ -26,7 +25,6 @@ class test_temperatures(unittest.TestCase):
     def tearDown(self):
         self.test_trans.rollback()
         self.test_conn.close()
-        self.test_db.drop_tables()
 
     def test_add_paper_temps(self):
         t1 = Time('2016-01-10 01:15:23', scale='utc')
@@ -49,8 +47,8 @@ class test_temperatures(unittest.TestCase):
         temp_dict = dict(zip(temp_colnames, temp_values))
         temp2_dict = dict(zip(temp_colnames, temp2_values))
 
-        self.test_session.add(temperatures.PaperTemperatures.new_from_text_row(t1, temp_list))
-        self.test_session.add(temperatures.PaperTemperatures.new_from_text_row(t2, temp2_list))
+        self.test_session.add_paper_temps(t1, temp_list)
+        self.test_session.add_paper_temps(t2, temp2_list)
 
         expected = [temperatures.PaperTemperatures(gps_time=t1.gps, jd_time=t1.jd, **temp_dict)]
         result = self.test_session.get_paper_temps(t1 - TimeDelta(3.0, format='sec'))

--- a/hera_mc/utils.py
+++ b/hera_mc/utils.py
@@ -1,0 +1,28 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2017 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+"""
+Common utility fuctions
+
+"""
+from astropy.time import Time
+from math import floor
+
+
+def calculate_obsid(starttime):
+    """
+    Create a new obsid using Astropy to compute the gps second.
+
+    Parameters:
+    ------------
+    starttime: astropy time object
+      observation starttime
+
+    Returns:
+    --------
+    obid
+    """
+    if not isinstance(starttime, Time):
+        raise ValueError('starttime must be an astropy Time object')
+
+    return int(floor(starttime.gps))

--- a/hera_mc/utils.py
+++ b/hera_mc/utils.py
@@ -7,6 +7,7 @@ Common utility fuctions
 """
 from astropy.time import Time
 from math import floor
+from .mc_session import MCSession
 
 
 def calculate_obsid(starttime):


### PR DESCRIPTION
These tables all have add_* and get_* methods and are fully covered by tests. The tables are also documented in docs/mc_definition.tex.

This PR also has some significant code reworking including:
- move MCSession object to it's own file
- define add_* methods on MCSession so add & get methods are on the same object
- define standard time filtering method used by get_* methods on MCSession
- define standard __eq__ and __repr__ methods on MCDeclarativeBase
- __eq__ method supports precision information per column for numeric types. these are defined in the table definition
- changed DOUBLE_PRECISION column types to Float because Float is mapped to DOUBLE PRECISION by default for postgresql
- defined all times in new tables in gps seconds rather than datetimes (this should be propagated to other tables)
