### PR TITLE
Set up Travis to use alembic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 alembic pandas matplotlib tabulate pytz pyproj nose pip
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 pandas matplotlib tabulate pytz pyproj nose pip
   - source activate test-environment
+  - conda install -c conda-forge alembic
   - pip install uptime
   - pip install coveralls
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 pandas matplotlib tabulate pytz pyproj nose pip
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 alembic pandas matplotlib tabulate pytz pyproj nose pip
   - source activate test-environment
   - pip install uptime
   - pip install coveralls
@@ -33,7 +33,7 @@ before_script:
   - psql -c 'create user hera;' -U postgres
   - mkdir ~/.hera_mc
   - cp ci/example_config.json ~/.hera_mc/mc_config.json
-  - python scripts/mc_initialize_db.py
+  - alembic upgrade head
 script: nosetests --with-coverage --cover-package=hera_mc
 
 after_success:

--- a/hera_mc/tests/test_default_db_schema.py
+++ b/hera_mc/tests/test_default_db_schema.py
@@ -11,6 +11,7 @@ from hera_mc.db_check import is_sane_database
 
 
 def test_default_db_schema():
+    # this test will fail if the default database schema does not match the code schema
 
     default_db = mc.connect_to_mc_db(None)
     engine = default_db.engine

--- a/hera_mc/tests/test_default_db_schema.py
+++ b/hera_mc/tests/test_default_db_schema.py
@@ -1,0 +1,23 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""
+Test that default database matches code schema.
+"""
+from sqlalchemy.orm import sessionmaker
+from hera_mc import mc, MCDeclarativeBase
+from hera_mc.db_check import is_sane_database
+
+
+def test_default_db_schema():
+
+    default_db = mc.connect_to_mc_db(None)
+    engine = default_db.engine
+    conn = engine.connect()
+    trans = conn.begin()
+
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    assert is_sane_database(MCDeclarativeBase, session) is True

--- a/hera_mc/version.py
+++ b/hera_mc/version.py
@@ -70,4 +70,5 @@ PACKAGE_DATA = {
         pjoin('data', 'test_data', '*.tst'),
     ]
 }
-REQUIRES = ["astropy", "sqlalchemy", "psycopg2", "uptime", "numpy", "tabulate", "matplotlib", "pandas", "pytz", "pyproj"]
+REQUIRES = ["astropy", "sqlalchemy", "psycopg2", "alembic", "uptime", "numpy",
+            "tabulate", "matplotlib", "pandas", "pytz", "pyproj"]


### PR DESCRIPTION
Make the Travis default database in production mode and use Alembic to create the schema.

Added a test that fails if the alembic revisions don't make the database match the code schema.