### PR TITLE
Remove dependency on "uptime" module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ install:
   - conda info -a
 
   # create environment and install dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 pandas matplotlib tabulate pyproj nose pip
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy astropy sqlalchemy psycopg2 pandas matplotlib tabulate psutil pyproj nose pip
   - source activate test-environment
   - conda install -c conda-forge alembic
-  - pip install uptime
   - pip install coveralls
   - python setup.py install
 services:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,6 @@ Python Prerequisites
 - numpy
 - astropy
 - tabulate
-- uptime
 - pandas
 - psutil
 - pyproj

--- a/hera_mc/host_status.py
+++ b/hera_mc/host_status.py
@@ -1,5 +1,5 @@
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2016 the HERA Collaboration
+# Copyright 2016-2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
 """M&C logging of the uptime, load, etc., on our computers out in the Karoo.
@@ -12,9 +12,10 @@ from __future__ import absolute_import, division, print_function
 
 import datetime
 import os
+import psutil
 import socket
-import uptime
 import numpy as np
+import time
 
 from sqlalchemy import BigInteger, Column, DateTime, Float, String, func
 
@@ -50,7 +51,7 @@ class HostStatus(MCDeclarativeBase):
         self.time = datetime.datetime.utcnow()
         self.hostname = socket.gethostname()
         self.load_average = os.getloadavg()[1]
-        self.uptime = uptime.uptime() / 86400.
+        self.uptime = (time.time() - psutil.boot_time()) / 86400.
 
     def __repr__(self):
         return('<HostStatus id={self.id} time={self.time} hostname={self.hostname} '

--- a/hera_mc/version.py
+++ b/hera_mc/version.py
@@ -70,5 +70,5 @@ PACKAGE_DATA = {
         pjoin('data', 'test_data', '*.tst'),
     ]
 }
-REQUIRES = ["astropy", "sqlalchemy", "psycopg2", "alembic", "uptime", "numpy",
+REQUIRES = ["astropy", "sqlalchemy", "psycopg2", "alembic", "numpy",
             "tabulate", "matplotlib", "pandas", "psutil", "pyproj"]

--- a/scripts/mc_server_status_daemon.py
+++ b/scripts/mc_server_status_daemon.py
@@ -21,7 +21,6 @@ from astropy.time import Time
 import netifaces
 import numpy as np
 import psutil
-import uptime
 
 from hera_mc import mc
 
@@ -123,7 +122,7 @@ with db.sessionmaker() as session:
                 system_time = Time.now()
                 num_cores = os.sysconf('SC_NPROCESSORS_ONLN')
                 cpu_load_pct = os.getloadavg()[1] / num_cores * 100.
-                uptime_days = uptime.uptime() / 86400.
+                uptime_days = (time.time() - psutil.boot_time()) / 86400.
 
                 memory_size_gb = vmem.total / 1024**3 # bytes => GiB
 


### PR DESCRIPTION
The "psutil" module provides the same functionality and is available in stock Anaconda, whereas "uptime" is not.