### PR TITLE
corrected feature that made running add_connection as a script difficult

### DIFF
--- a/scripts/add_connection.py
+++ b/scripts/add_connection.py
@@ -30,7 +30,7 @@ def query_args(args):
         args.dnrev = raw_input('Downstream part revision:  ')
     if args.dnport is None:
         args.dnport = raw_input('Downstream input port:  ')
-    if args.date == 'now':
+    if args.date == 'now': # note that 'now' is the current default.
         args.date = cm_utils._query_default('date', args)
     return args
 

--- a/scripts/add_connection.py
+++ b/scripts/add_connection.py
@@ -30,7 +30,8 @@ def query_args(args):
         args.dnrev = raw_input('Downstream part revision:  ')
     if args.dnport is None:
         args.dnport = raw_input('Downstream input port:  ')
-    args.date = cm_utils._query_default('date', args)
+    if args.date == 'now':
+        args.date = cm_utils._query_default('date', args)
     return args
 
 


### PR DESCRIPTION
The add_connection script would always query for the date, which is annoying when you have a script running a couple of hundred times...