### PR TITLE
DB checks

### DIFF
--- a/hera_mc/db_check.py
+++ b/hera_mc/db_check.py
@@ -5,7 +5,28 @@ from sqlalchemy.orm import RelationshipProperty
 from . import logger
 
 
-def is_sane_database(base, session):
+def check_connection(session):
+    """
+    Check whether the database connection is live and responsive.
+
+    Parameters
+    ----------
+    session: SQLAlchemy session bound to an engine
+
+    Returns
+    ---------
+    True if database responds to simple SQL query. Otherwise False.
+    """
+    from sqlalchemy.exc import OperationalError
+    result = True
+    try:
+        r = session.execute('SELECT 1')
+    except OperationalError:
+        result = False
+    return result
+
+
+def is_valid_database(base, session):
     """
     Check whether the current database matches the models declared in model
     base.
@@ -49,7 +70,7 @@ def is_sane_database(base, session):
         if table in tables:
             # Check all columns are found
             # Looks like [{'default':
-            #                  "nextval('sanity_check_test_id_seq'::regclass)",
+            #                  "nextval('validity_check_test_id_seq'::regclass)",
             #              'autoincrement': True, 'nullable': False,
             #              'type': INTEGER(), 'name': 'id'}]
 
@@ -58,7 +79,7 @@ def is_sane_database(base, session):
 
             for column_prop in mapper.attrs:
                 if isinstance(column_prop, RelationshipProperty):
-                    # TODO: Add sanity checks for relations
+                    # TODO: Add validity checks for relations
                     pass
                 else:
                     for column in column_prop.columns:

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -194,6 +194,7 @@ def connect_to_mc_db(args, forced_db_name=None):
 
     # Test validity of database
     with db.sessionmaker() as session:
+        from . import db_check
         if not db_check.is_sane_database(None, session):
             raise AssertionError('cannot connect to M&C database: '
                                  'is_sane_database failed.')

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -192,6 +192,12 @@ def connect_to_mc_db(args, forced_db_name=None):
                            'the DB named {1!r} in {2!r}'.format(db_mode, db_name,
                                                                 config_path))
 
+    # Test validity of database
+    with db.sessionmaker() as session:
+        if not db_check.is_sane_database(None, session):
+            raise AssertionError('cannot connect to M&C database: '
+                                 'is_sane_database failed.')
+
     return db
 
 

--- a/hera_mc/tests/test_default_db_schema.py
+++ b/hera_mc/tests/test_default_db_schema.py
@@ -7,7 +7,7 @@ Test that default database matches code schema.
 """
 from sqlalchemy.orm import sessionmaker
 from hera_mc import mc, MCDeclarativeBase
-from hera_mc.db_check import is_sane_database
+from hera_mc.db_check import is_valid_database
 
 
 def test_default_db_schema():
@@ -21,4 +21,4 @@ def test_default_db_schema():
     Session = sessionmaker(bind=engine)
     session = Session()
 
-    assert is_sane_database(MCDeclarativeBase, session) is True
+    assert is_valid_database(MCDeclarativeBase, session) is True

--- a/scripts/mc_check_db_schema.py
+++ b/scripts/mc_check_db_schema.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 from hera_mc import MCDeclarativeBase, mc
-from hera_mc.db_check import is_sane_database
+from hera_mc.db_check import is_valid_database
 
 parser = mc.get_mc_argument_parser()
 args = parser.parse_args()
@@ -21,5 +21,5 @@ except RuntimeError as e:
 # in production mode, so let's just check again.
 
 with db.sessionmaker() as session:
-    if not is_sane_database(MCDeclarativeBase, session):
+    if not is_valid_database(MCDeclarativeBase, session):
         raise SystemExit('database {0} does not match expected schema'.format(db.engine.url))

--- a/scripts/mc_server_status_daemon.py
+++ b/scripts/mc_server_status_daemon.py
@@ -25,7 +25,7 @@ import psutil
 from hera_mc import mc
 
 
-# Preliminaries. We have a small sanity check since the M&C design specifies
+# Preliminaries. We have a small validity check since the M&C design specifies
 # the memory, network, and system load are to be 5-minute averages.
 
 MONITORING_INTERVAL = 60  # seconds


### PR DESCRIPTION
I've added a simple `check_connection` function which checks the connection to a DB by executing a trivial query. This check is run by default at the end of `mc.connect_to_mc_db`, but can be turned off.

While I was in there digging I renamed `is_sane_database` to `is_valid_database` and changed references to the old language.