### PR TITLE
Update RTP Status table

### DIFF
--- a/alembic/versions/e1ca8599e705_update_rtp_status_table.py
+++ b/alembic/versions/e1ca8599e705_update_rtp_status_table.py
@@ -1,0 +1,28 @@
+"""Update RTP status table
+
+Revision ID: e1ca8599e705
+Revises: 8e7282ae4840
+Create Date: 2017-08-15 21:03:28.459132+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e1ca8599e705'
+down_revision = '8e7282ae4840'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('rtp_status_pkey', 'rtp_status', type_='primary')
+    op.add_column('rtp_status', sa.Column('hostname', sa.String(length=32)))
+    op.create_primary_key('rtp_status_pkey', 'rtp_status', ['time', 'hostname'])
+
+
+def downgrade():
+    op.drop_constraing('rtp_status_pkey', 'rtp_status', type_='primary')
+    op.drop_column('rtp_status', 'hostname')
+    op.create_primary_key('rtp_status_pkey', 'rtp_status', ['time', ])

--- a/alembic/versions/e1ca8599e705_update_rtp_status_table.py
+++ b/alembic/versions/e1ca8599e705_update_rtp_status_table.py
@@ -23,6 +23,6 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_constraing('rtp_status_pkey', 'rtp_status', type_='primary')
+    op.drop_constraint('rtp_status_pkey', 'rtp_status', type_='primary')
     op.drop_column('rtp_status', 'hostname')
     op.create_primary_key('rtp_status_pkey', 'rtp_status', ['time', ])

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -558,8 +558,8 @@ class MCSession(Session):
 
         return file_list
 
-    def add_rtp_status(self, time, status, event_min_elapsed, num_processes,
-                       restart_hours_elapsed):
+    def add_rtp_status(self, time, hostname, status, event_min_elapsed,
+                       num_processes, restart_hours_elapsed):
         """
         Add a new rtp_status object.
 
@@ -567,6 +567,8 @@ class MCSession(Session):
         ------------
         time: astropy time object
             time of this status
+        hostname: string
+            hostname of server
         status: string
             status (options TBD)
         event_min_elapsed: float
@@ -578,8 +580,8 @@ class MCSession(Session):
         """
         from .rtp import RTPStatus
 
-        self.add(RTPStatus.create(time, status, event_min_elapsed, num_processes,
-                                  restart_hours_elapsed))
+        self.add(RTPStatus.create(time, hostname, status, event_min_elapsed,
+                                  num_processes, restart_hours_elapsed))
 
     def get_rtp_status(self, starttime, stoptime=None):
         """

--- a/hera_mc/rtp.py
+++ b/hera_mc/rtp.py
@@ -27,6 +27,7 @@ class RTPStatus(MCDeclarativeBase):
     Definition of rtp_status table.
 
     time: time of this status in floor(gps seconds) (BigInteger). Primary_key
+    hostname: hostname of server (String)
     status: status (options TBD) (String)
     event_min_elapsed: minutes elapsed since last event (Float)
     num_processes: number of processes running (Integer)
@@ -34,6 +35,7 @@ class RTPStatus(MCDeclarativeBase):
     """
     __tablename__ = 'rtp_status'
     time = Column(BigInteger, primary_key=True, autoincrement=False)
+    hostname = Column(String(32), primary_key=True)
     status = Column(String(64), nullable=False)  # should this be an enum? or text?
     event_min_elapsed = Column(Float, nullable=False)
     num_processes = Column(Integer, nullable=False)
@@ -43,7 +45,7 @@ class RTPStatus(MCDeclarativeBase):
             'restart_hours_elapsed': DEFAULT_HOUR_TOL}
 
     @classmethod
-    def create(cls, time, status, event_min_elapsed, num_processes,
+    def create(cls, time, hostname, status, event_min_elapsed, num_processes,
                restart_hours_elapsed):
         """
         Create a new rtp_status object.
@@ -52,6 +54,8 @@ class RTPStatus(MCDeclarativeBase):
         ------------
         time: astropy time object
             time of this status
+        hostname: string
+            name of server
         status: string
             status (options TBD)
         event_min_elapsed: float
@@ -65,7 +69,8 @@ class RTPStatus(MCDeclarativeBase):
             raise ValueError('time must be an astropy Time object')
         time = floor(time.gps)
 
-        return cls(time=time, status=status, event_min_elapsed=event_min_elapsed,
+        return cls(time=time, hostname=hostname, status=status,
+                   event_min_elapsed=event_min_elapsed,
                    num_processes=num_processes,
                    restart_hours_elapsed=restart_hours_elapsed)
 

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -29,9 +29,9 @@ class TestRTP(TestHERAMC):
                                    obsid]
         self.observation_columns = dict(zip(self.observation_names,
                                             self.observation_values))
-        self.status_names = ['time', 'status', 'event_min_elapsed',
+        self.status_names = ['time', 'hostname', 'status', 'event_min_elapsed',
                              'num_processes', 'restart_hours_elapsed']
-        self.status_values = [time, 'happy', 3.6, 8, 10.2]
+        self.status_values = [time, 'still1', 'happy', 3.6, 8, 10.2]
         self.status_columns = dict(zip(self.status_names, self.status_values))
 
         self.event_names = ['time', 'obsid', 'event']
@@ -81,6 +81,7 @@ class TestRTP(TestHERAMC):
         new_status_time = self.status_columns['time'] + TimeDelta(5 * 60, format='sec')
         new_status = 'unhappy'
         self.test_session.add_rtp_status(new_status_time,
+                                         self.status_columns['hostname'],
                                          new_status,
                                          self.status_columns['event_min_elapsed'] + 5,
                                          self.status_columns['num_processes'],


### PR DESCRIPTION
This PR adds the hostname as part of the RTP Status table, and uses the hostname + time as the primary key. This avoids having multiple hosts check in simultaneously and create a collision. The alembic commands were made by hand, so comments on them are most welcome.