### PR TITLE
chk_revisions work for overlapping

### DIFF
--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -27,6 +27,7 @@ class TestParts(TestHERAMC):
         self.test_part = 'test_part'
         self.test_rev = 'Q'
         self.start_time = Time('2017-07-01 01:00:00', scale='utc')
+        self.now = cm_utils._get_astropytime('now')
         self.h = cm_handling.Handling(self.test_session)
 
         # Add a test part
@@ -84,22 +85,25 @@ class TestParts(TestHERAMC):
             self.assertFalse()
 
     def test_get_revisions_of_type(self):
-        at_date = self.start_time
-        full_req = ['vapor']
-        rev_types = ['LAST', 'ACTIVE', 'ALL', self.test_rev]  # , 'FULL']
+        at_date = self.now
+        fr = ['f_engine']
+        rev_types = ['LAST', 'ACTIVE', 'ALL', 'FULL', 'A']
         for rq in rev_types:
-            revision = cm_revisions.get_revisions_of_type(self.test_part, rq, at_date, full_req, self.test_session)
-            self.assertTrue(revision[0].rev == self.test_rev)
+            revision = cm_revisions.get_revisions_of_type('HH0', rq, at_date, fr, self.test_session)
+            self.assertTrue(revision[0].rev == 'A')
 
     def test_check_overlapping(self):
         c = cm_revisions.check_part_for_overlapping_revisions(self.test_part, self.test_session)
         self.assertTrue(len(c) == 0)
 
     def test_check_rev(self):
-        full_req = ['vapor']
-        rev_types = ['LAST', 'ACTIVE']  # , 'FULL']
+        fr = ['f_engine']
+        tcr = {'LAST': [self.test_part, self.test_rev],
+               'ACTIVE': [self.test_part, self.test_rev],
+               'FULL': ['HH0', 'A']}
+        rev_types = ['LAST', 'ACTIVE', 'FULL']
         for r in rev_types:
-            c = cm_revisions.check_rev(self.test_part, self.test_rev, r, self.start_time, full_req, self.test_session)
+            c = cm_revisions.check_rev(tcr[r][0], tcr[r][1], r, self.now, fr, self.test_session)
             self.assertTrue(c)
 
     def test_datetime(self):

--- a/scripts/chk_revisions.py
+++ b/scripts/chk_revisions.py
@@ -3,9 +3,12 @@
 # Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
-"""This is meant to hold scripts to check various parts/revisions
-
 """
+This checks either a supplied part list or all of the parts
+to find whether it has any overlapping revisions in time.  It
+only prints a warning and the info.
+"""
+
 from __future__ import absolute_import, division, print_function
 from hera_mc import mc, cm_revisions, cm_handling, cm_utils
 import sys

--- a/scripts/chk_revisions.py
+++ b/scripts/chk_revisions.py
@@ -34,17 +34,12 @@ if __name__ == '__main__':
     else:
         args.part = [args.part]
 
-    overlapping = {}
     found_some = False
     for p in args.part:
         overlap = cm_revisions.check_part_for_overlapping_revisions(p, session)
         if len(overlap) > 0:
-            overlapping[p] = overlap
             found_some = True
     if found_some:
-        print("Overlapping part revisions are:")
-        for k, p in overlapping.iteritems():
-            if len(p) > 0:
-                print('\t' + p)
+        print("Overlapping part revisions were found.")
     else:
         print("No overlapping part revisions were found.")

--- a/scripts/chk_revisions.py
+++ b/scripts/chk_revisions.py
@@ -40,7 +40,7 @@ if __name__ == '__main__':
     found_some = False
     for p in args.part:
         overlap = cm_revisions.check_part_for_overlapping_revisions(p, session)
-        if len(overlap) > 0:
+        if len(overlap):
             found_some = True
     if found_some:
         print("Overlapping part revisions were found.")

--- a/scripts/chk_revisions.py
+++ b/scripts/chk_revisions.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- mode: python; coding: utf-8 -*-
-# Copyright 2016 the HERA Collaboration
+# Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
 """This is meant to hold scripts to check various parts/revisions

--- a/scripts/chk_revisions.py
+++ b/scripts/chk_revisions.py
@@ -1,0 +1,50 @@
+#! /usr/bin/env python
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""This is meant to hold scripts to check various parts/revisions
+
+"""
+from __future__ import absolute_import, division, print_function
+from hera_mc import mc, cm_revisions, cm_handling, cm_utils
+import sys
+
+if __name__ == '__main__':
+    parser = mc.get_mc_argument_parser()
+    parser.add_argument('-p', '--part', help="Part number or list (comma-separated, no spaces)", default=None)
+
+    args = parser.parse_args()
+
+    # start session
+    db = mc.connect_to_mc_db(args)
+    session = db.sessionmaker()
+    h = cm_handling.Handling(session)
+    at_date = cm_utils._get_astropytime('now')
+
+    if args.part is None:
+        part_dict = h.get_part_types(at_date, show_hptype=True)
+        args.part = []
+        for k, v in part_dict.iteritems():
+            for p in v['part_list']:
+                if p not in args.part:
+                    args.part.append(p)
+    elif ',' in args.part:
+        args.part = args.part.split(',')
+    else:
+        args.part = [args.part]
+
+    overlapping = {}
+    found_some = False
+    for p in args.part:
+        overlap = cm_revisions.check_part_for_overlapping_revisions(p, session)
+        if len(overlap) > 0:
+            overlapping[p] = overlap
+            found_some = True
+    if found_some:
+        print("Overlapping part revisions are:")
+        for k, p in overlapping.iteritems():
+            if len(p) > 0:
+                print('\t' + p)
+    else:
+        print("No overlapping part revisions were found.")


### PR DESCRIPTION
Just added chk_revisions.py file to check for overlapping part revisions.  To my surprise, it found none.