### PR TITLE
Cm version fix

### DIFF
--- a/hera_mc/cm_handling.py
+++ b/hera_mc/cm_handling.py
@@ -75,8 +75,10 @@ class Handling:
         at_date = cm_utils._get_astropytime(at_date)
 
         # get last row before at_date
-        self.session.query(CMVersion).filter(CMVersion.update_time < at_date.gps).order_by(
+        result = self.session.query(CMVersion).filter(CMVersion.update_time < at_date.gps).order_by(
             desc(CMVersion.update_time)).limit(1).all()
+
+        return result[0].git_hash
 
     def is_in_connections(self, hpn, rev='ACTIVE', return_active=False):
         """

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -10,6 +10,8 @@
 from __future__ import absolute_import, division, print_function
 
 import unittest
+import os.path
+import subprocess
 import numpy as np
 from hera_mc import geo_location, geo_handling, mc, cm_transfer
 from hera_mc.tests import TestHERAMC
@@ -142,6 +144,13 @@ class TestGeo(TestHERAMC):
                          set([0]))
 
         self.assertTrue(corr_dict['cm_version'] is not None)
+
+        # cm_version should be the same as the git hash of m&c for the test data
+        mc_dir = os.path.dirname(os.path.realpath(__file__))
+        mc_git_hash = subprocess.check_output(['git', '-C', mc_dir, 'rev-parse', 'HEAD'],
+                                              stderr=subprocess.STDOUT).strip()
+        self.assertEqual(corr_dict['cm_version'], mc_git_hash)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -141,6 +141,7 @@ class TestGeo(TestHERAMC):
         self.assertEqual(set(corr_dict['antenna_numbers']),
                          set([0]))
 
+        self.assertTrue(corr_dict['cm_version'] is not None)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes the fact that the get_cm_version method was not actually returning the cm_version as it should have been, and adds tests that would have caught the error.