### PR TITLE
Change hookup to use a "local" file to speed it up.

### DIFF
--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -69,7 +69,7 @@ class Hookup:
         force_new:  boolean to force a full database read as opposed to checking file
         force_specific:  boolean to force this to read/write the file to use the supplied values
         """
-        if force_specfic:
+        if force_specific:
             force_new = True
         if force_new or not self.check_if_hookup_file_is_current():
             if force_specific:
@@ -78,7 +78,7 @@ class Hookup:
                 p = port_query
             else:
                 h = self.hookup_list_to_cache
-                r = 'LAST'
+                r = 'ACTIVE'
                 p = 'all'
             hookup_dict = self.__get_hookup(hpn_list=h, rev=r, port_query=p,
                                             at_date=at_date, exact_match=exact_match, show_levels=show_levels)
@@ -87,20 +87,20 @@ class Hookup:
             hookup_dict = self.read_hookup_from_file()
             if show_levels:
                 hookup_dict = self.__hookup_add_correlator_levels(hookup_dict)
-
         # Now we need to delete the ones we don't use since the file (probably) has all of them.
-        for k in hookup_dict['hookup'].keys():
-            if exact_match:
-                if k not in hpn_list:
-                    del hookup_dict['hookup'][k]
-            else:
-                del_this_one = True
-                for p in hpn_list:
-                    if k.lower()[:len(p)] == p.lower():
-                        del_this_one = False
-                        break
-                if del_this_one:
-                    del hookup_dict['hookup'][k]
+        if not force_specific:
+            for k in hookup_dict['hookup'].keys():
+                if exact_match:
+                    if k not in hpn_list:
+                        del hookup_dict['hookup'][k]
+                else:
+                    del_this_one = True
+                    for p in hpn_list:
+                        if k.lower()[:len(p)] == p.lower():
+                            del_this_one = False
+                            break
+                    if del_this_one:
+                        del hookup_dict['hookup'][k]
         return hookup_dict
 
     def __get_hookup(self, hpn_list, rev, port_query, at_date,
@@ -118,7 +118,7 @@ class Hookup:
                                                full_version=False)
         print(hpn_list)
         print(parts)
-        hookup_dict = {'hookup': {}, 'fully_connected': {}, 'parts_epoch': []}
+        hookup_dict = {'hookup': {}, 'fully_connected': {}, 'parts_epoch': {}}
         part_types_found = []
         for k, part in parts.iteritems():
             if not cm_utils._is_active(self.at_date, part['part'].start_date, part['part'].stop_date):

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -7,15 +7,14 @@
 This is computes and displays part hookups.
 
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import print_function
 from tabulate import tabulate
 import sys
+import numpy as np
 
 from hera_mc import mc, geo_location, correlator_levels, cm_utils, cm_handling
 from hera_mc import part_connect as PC
 import copy
-import warnings
-from argparse import Namespace
 from sqlalchemy import func
 
 
@@ -24,11 +23,10 @@ class Hookup:
     Class to find and display the signal path hookup.
     """
 
-    def __init__(self, session=None):
+    def __init__(self, session=None, hookup_list_to_cache=['HH']):
         """
         Hookup traces parts and connections through the signal path (as defined
             by the connections).
-        The only external method is get_hookup(...)
         """
 
         if session is None:
@@ -38,11 +36,17 @@ class Hookup:
             self.session = session
         self.handling = cm_handling.Handling(session)
         self.part_type_cache = {}
+        self.hookup_local_file = 'hookup_tmp.npy'
+        self.part_type_cache_file = 'part_type_cache_tmp.npy'
+        self.hookup_list_to_cache = hookup_list_to_cache
 
-    def get_hookup(self, hpn_list, rev, port_query, at_date,
-                   exact_match=False, show_levels=False):
+    def get_hookup(self, hpn_list, rev, port_query='all', at_date='now',
+                   exact_match=False, show_levels=False,
+                   force_new=True, force_specific=False):
         """
-        Return the full hookup to the supplied part/rev/port in the form of a dictionary
+        Return the full hookup to the supplied part/rev/port in the form of a dictionary.
+        Unless force_new is True, it will check a local hookup file and return that if current
+        otherwise it will go through the full database to get hookup.
         Returns hookup_dict, a dictionary with the following entries:
             'hookup': another dictionary keyed on part then pol (e/n)
             'columns': names of parts that are used in displaying the hookup as column headers
@@ -62,6 +66,47 @@ class Hookup:
         at_date:  date for hookup validity
         exact_match:  boolean for either exact_match or partial
         show_levels:  boolean to include correlator levels
+        force_new:  boolean to force a full database read as opposed to checking file
+        force_specific:  boolean to force this to read/write the file to use the supplied values
+        """
+        if force_specfic:
+            force_new = True
+        if force_new or not self.check_if_hookup_file_is_current():
+            if force_specific:
+                h = hpn_list
+                r = rev
+                p = port_query
+            else:
+                h = self.hookup_list_to_cache
+                r = 'LAST'
+                p = 'all'
+            hookup_dict = self.__get_hookup(hpn_list=h, rev=r, port_query=p,
+                                            at_date=at_date, exact_match=exact_match, show_levels=show_levels)
+            self.write_hookup_to_file(hookup_dict)
+        else:
+            hookup_dict = self.read_hookup_from_file()
+            if show_levels:
+                hookup_dict = self.__hookup_add_correlator_levels(hookup_dict)
+
+        # Now we need to delete the ones we don't use since the file (probably) has all of them.
+        for k in hookup_dict['hookup'].keys():
+            if exact_match:
+                if k not in hpn_list:
+                    del hookup_dict['hookup'][k]
+            else:
+                del_this_one = True
+                for p in hpn_list:
+                    if k.lower()[:len(p)] == p.lower():
+                        del_this_one = False
+                        break
+                if del_this_one:
+                    del hookup_dict['hookup'][k]
+        return hookup_dict
+
+    def __get_hookup(self, hpn_list, rev, port_query, at_date,
+                     exact_match=False, show_levels=False):
+        """
+        This gets called by the get_hookup wrapper if the database is to be read.
         """
 
         self.at_date = cm_utils._get_astropytime(at_date)
@@ -71,6 +116,8 @@ class Hookup:
                                                at_date=self.at_date,
                                                exact_match=exact_match,
                                                full_version=False)
+        print(hpn_list)
+        print(parts)
         hookup_dict = {'hookup': {}, 'fully_connected': {}, 'parts_epoch': []}
         part_types_found = []
         for k, part in parts.iteritems():
@@ -282,14 +329,15 @@ class Hookup:
     def __hookup_add_correlator_levels(self, hookup_dict):
         import os.path
         dummy_file = os.path.join(mc.test_data_path, 'levels.tst')
-        hookup_dict['columns'].append('level')
+        if 'level' not in hookup_dict['columns']:
+            hookup_dict['columns'].append('level')
         hookup_dict['levels'] = {}
         pf_input = []
         sorted_hkeys = sorted(hookup_dict['hookup'].keys())
         # *** These nested loops must be in the same order as below ***
         for k in sorted_hkeys:
             for p in sorted(hookup_dict['hookup'][k].keys()):
-                if len(hookup_dict['hookup'][k][p]):
+                if hookup_dict['fully_connected'][k][p]:
                     f_engine = hookup_dict['hookup'][k][p][-1].downstream_part
                 else:
                     f_engine = None
@@ -368,8 +416,31 @@ class Hookup:
         else:
             return num_fully_connected > 0
 
+    def write_hookup_to_file(self, hookup_dict):
+        np.save(self.hookup_local_file, hookup_dict)
+        np.save(self.part_type_cache_file, self.part_type_cache)
+
+    def check_if_hookup_file_is_current(self):
+        import os
+        import time
+        from astropy.time import Time
+        from hera_mc import cm_transfer
+        if os.path.isfile(self.hookup_local_file):
+            result = self.session.query(cm_transfer.CMVersion).order_by(cm_transfer.CMVersion.update_time).all()
+            cm_hash_time = Time(result[-1].update_time, format='gps')
+            stats = os.stat(self.hookup_local_file)
+            file_mod_time = Time(stats.st_mtime, format='unix')
+            return file_mod_time > cm_hash_time
+        else:
+            return False
+
+    def read_hookup_from_file(self):
+        hookup_dict = np.load(self.hookup_local_file).item()
+        self.part_type_cache = np.load(self.part_type_cache_file).item()
+        return hookup_dict
+
     def show_hookup(self, hookup_dict, cols_to_show='all', show_levels=False, show_ports=True, show_revs=True,
-                    show_state='active', file=None, output_format='ascii'):
+                    show_state='full', file=None, output_format='ascii'):
         """
         Print out the hookup table -- uses tabulate package.
 
@@ -384,7 +455,7 @@ class Hookup:
         file:  file to use, None goes to stdout
         output_format:  set to html for the web-page version
         """
-        headers = self.__make_header_row(hookup_dict['columns'], cols_to_show)
+        headers = self.__make_header_row(hookup_dict['columns'], cols_to_show, show_levels)
         table_data = []
         numerical_keys = cm_utils.put_keys_in_numerical_order(sorted(hookup_dict['hookup'].keys()))
         for hukey in numerical_keys:
@@ -412,11 +483,13 @@ class Hookup:
             table = '<html>\n\t<body>\n\t\t<pre>\n' + table + '\t\t</pre>\n\t</body>\n</html>\n'
         print(table, file=file)
 
-    def __make_header_row(self, header_col_list, cols_to_show):
+    def __make_header_row(self, header_col_list, cols_to_show, show_levels):
         headers = []
         show_flag = []
         for col in header_col_list:
-            if cols_to_show[0].lower() == 'all' or col in cols_to_show:
+            if show_levels and col == 'level':
+                headers.append(col)
+            elif cols_to_show[0].lower() == 'all' or col in cols_to_show:
                 headers.append(col)
         return headers
 

--- a/hera_mc/cm_revisions.py
+++ b/hera_mc/cm_revisions.py
@@ -269,7 +269,7 @@ def get_full_revision(hpn, at_date, session=None):
         raise RevisionException(hpn)
 
     hookup = cm_hookup.Hookup(session)
-    hu = hookup.get_hookup([hpn], rev[0].rev, 'all', at_date, True)
+    hu = hookup.get_hookup([hpn], rev[0].rev, 'all', at_date, True, force_specific=True)
     return_full = []
     if hookup.is_fully_connected(hu, 'all'):
         return_full.append(Namespace(hpn=hpn, rev=rev[0].rev,

--- a/hera_mc/correlator_levels.py
+++ b/hera_mc/correlator_levels.py
@@ -18,7 +18,7 @@ DF_chassis_list = ['1', '2', '3', '4', '5', '6', '7', '8']
 default_levels_filename = 'levels.tmp'
 
 
-def get_levels(pf_input, testing, network='local', timeout=5):
+def get_levels(pf_input, testing, network='local', timeout=2):
     """
     This returns a dictionary containing the correlator levels for inputs givin in pf_input.
     This assumes the f-engine name structure of 'DF<int=pf_chassis><letter=input_row><int=input_col>'
@@ -48,6 +48,8 @@ def get_levels(pf_input, testing, network='local', timeout=5):
         if levels is None:
             print('No valid correlator level file.')
             pf_levels.append('X')
+        elif pf is None:
+            pf_levels.append('-')
         elif valid_input_name(pf):
             pf_chassis = 'F' + str(pf[2])
             pf_rowcol_designator = pf[-2:]

--- a/hera_mc/sys_handling.py
+++ b/hera_mc/sys_handling.py
@@ -367,11 +367,14 @@ class Handling:
         return pams
 
     def publish_summary(self, hlist=['HH'], rev='A', exact_match=False,
-                        hookup_cols=['station', 'front-end', 'cable-post-amp(in)', 'post-amp', 'cable-container', 'f-engine', 'level']):
+                        hookup_cols=['station', 'front-end', 'cable-post-amp(in)', 'post-amp', 'cable-container', 'f-engine', 'level'],
+                        force_new_hookup_dict=True, force_specific_hookup_dict=False):
         output_file = 'sys_conn_tmp.html'
         location_on_paper1 = 'paper1:/home/davidm/local/src/rails-paper/public'
         hookup_dict = self.hookup.get_hookup(hpn_list=hlist, rev=rev, port_query='all',
-                                             at_date='now', exact_match=exact_match, show_levels=True)
+                                             at_date='now', exact_match=exact_match, show_levels=True,
+                                             force_new=force_new_hookup_dict, force_specific=force_specific_hookup_dict)
+
         with open(output_file, 'w') as f:
             self.hookup.show_hookup(hookup_dict=hookup_dict, cols_to_show=hookup_cols, show_levels=True, show_ports=False,
                                     show_revs=False, show_state='full', file=f, output_format='html')

--- a/hera_mc/tests/test_sys_handling.py
+++ b/hera_mc/tests/test_sys_handling.py
@@ -103,7 +103,7 @@ class TestGeo(TestHERAMC):
     def test_correlator_levels(self):
         at_date = cm_utils._get_astropytime('2017-07-03')
         H = cm_hookup.Hookup(self.test_session)
-        hu = H.get_hookup(['HH23'], 'A', 'all', at_date, exact_match=True, show_levels=True)
+        hu = H.get_hookup(['HH23'], 'A', 'all', at_date, exact_match=True, show_levels=True, force_specific=True)
         hh23level = float(hu['levels']['HH23:A']['e'])
         self.assertEqual(type(hh23level), float)
         # Now get some failures
@@ -132,7 +132,7 @@ class TestGeo(TestHERAMC):
         connection.start_gpstime = self.test_time
         self.test_session.add(connection)
         self.test_session.commit()
-        hu = H.get_hookup(['test_part1'], 'Q', 'all', at_date, exact_match=True, show_levels=True)
+        hu = H.get_hookup(['test_part1'], 'Q', 'all', at_date, exact_match=True, show_levels=True, force_specific=True)
         tplevel = hu['levels']['test_part1:Q']['e']
         print(tplevel)
         self.assertEqual(tplevel, '-')

--- a/scripts/hookup.py
+++ b/scripts/hookup.py
@@ -18,6 +18,8 @@ if __name__ == '__main__':
     parser.add_argument('-e', '--exact-match', help="Force exact matches on part numbers, not beginning N char. [False]",
                         dest='exact_match', action='store_true')
     parser.add_argument('-q', '--quick', help="Shortcut to show a subset of cols and correlator level", action='store_true')
+    parser.add_argument('-f', '--force-new', dest='force_new', help="Force it to write a new hookup file.", action='store_true')
+    parser.add_argument('--force-specific', dest='force_specific', help="Force db and local cache file to use these values", action='store_true')
     parser.add_argument('--port', help="Define desired port(s) for hookup. [all]", dest='port', default='all')
     parser.add_argument('--show-state', help="Show 'full' or 'all' hookups [full]", dest='show_state', default='full')
     parser.add_argument('--hookup-cols', help="Specify a subset of parts to show in mapr, comma-delimited no-space list. [all]",
@@ -44,6 +46,7 @@ if __name__ == '__main__':
     hookup = cm_hookup.Hookup(session)
     hookup_dict = hookup.get_hookup(hpn_list=args.hpn, rev=args.revision, port_query=args.port,
                                     at_date=date_query, exact_match=args.exact_match,
-                                    show_levels=args.show_levels)
+                                    show_levels=args.show_levels,
+                                    force_new=args.force_new, force_specific=args.force_specific)
     hookup.show_hookup(hookup_dict=hookup_dict, cols_to_show=args.hookup_cols, show_levels=args.show_levels,
                        show_ports=args.show_ports, show_revs=args.show_revs, show_state=args.show_state)

--- a/scripts/mc_publish_sys_levels.py
+++ b/scripts/mc_publish_sys_levels.py
@@ -19,6 +19,8 @@ if __name__ == '__main__':
     parser.add_argument('-r', '--revision', help="Specify revision or last/active/full/all for hpn.  [A]", default='A')
     parser.add_argument('-e', '--exact-match', help="Force exact matches on part numbers, not beginning N char. [False]",
                         dest='exact_match', action='store_true')
+    parser.add_argument('-f', '--force-new', dest='force_new', help="Force it to write a new hookup file.", action='store_true')
+    parser.add_argument('--force-specific', dest='force_specific', help="Force db and local cache file to use these values", action='store_true')
     parser.add_argument('--hookup-cols', help="Specify a subset of parts to show in mapr, comma-delimited no-space list.",
                         dest='hookup_cols', default=default_hookup_cols)
 
@@ -33,4 +35,5 @@ if __name__ == '__main__':
     session = db.sessionmaker()
 
     system = sys_handling.Handling(session)
-    system.publish_summary(args.hpn, rev=args.revision, exact_match=args.exact_match, hookup_cols=args.hookup_cols)
+    system.publish_summary(args.hpn, rev=args.revision, exact_match=args.exact_match, hookup_cols=args.hookup_cols,
+                           force_new_hookup_dict=args.force_new)


### PR DESCRIPTION
This changes hookup to use a local file if it is time-stamped after the latest cm_version table entry.
You can force it to use a new hookup and you can also force it to act as it did previously.