### PR TITLE
Fixcache

### DIFF
--- a/hera_mc/cm_handling.py
+++ b/hera_mc/cm_handling.py
@@ -226,7 +226,7 @@ class Handling:
         for hpnr in sorted(part_dossier.keys()):
             pdpart = part_dossier[hpnr]['part']
             is_active = cm_utils.is_active(part_dossier[hpnr]['Time'],
-                                            pdpart.start_date, pdpart.stop_date)
+                                           pdpart.start_date, pdpart.stop_date)
             if (is_active and len(part_dossier[hpnr]['connections']) > 0):
                 is_connected = 'Yes'
             elif is_active:
@@ -351,9 +351,9 @@ class Handling:
                             conn.upstream_output_port.lower() == port.lower()):
                         conn.gps2Time()
                         ckey = cm_utils.make_connection_key(conn.downstream_part,
-                                                             conn.down_part_rev,
-                                                             conn.downstream_input_port,
-                                                             conn.start_gpstime)
+                                                            conn.down_part_rev,
+                                                            conn.downstream_input_port,
+                                                            conn.start_gpstime)
                         connection_dossier['connections'][ckey] = copy.copy(conn)
                         down_parts.append(ckey)
                 # Find where the part is in the downward position, so identify its upward connection
@@ -364,9 +364,9 @@ class Handling:
                             conn.downstream_input_port.lower() == port.lower()):
                         conn.gps2Time()
                         ckey = cm_utils.make_connection_key(conn.upstream_part,
-                                                             conn.up_part_rev,
-                                                             conn.upstream_output_port,
-                                                             conn.start_gpstime)
+                                                            conn.up_part_rev,
+                                                            conn.upstream_output_port,
+                                                            conn.start_gpstime)
                         connection_dossier['connections'][ckey] = copy.copy(conn)
                         up_parts.append(ckey)
                 if len(up_parts) == 0:

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -128,6 +128,7 @@ class Hookup:
         exact_match:  boolean for either exact_match or partial
         show_levels:  boolean to include correlator levels
         force_new:  boolean to force a full database read as opposed to checking file
+                    this will also rewrite the cache-file
         force_specific:  boolean to force this to read/write the file to use the supplied values
                          Setting this makes get_hookup provide specific hookups (mimicking the
                          action before the cache file option was instituted)

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -194,7 +194,7 @@ class Hookup:
         for k, part in parts.iteritems():
             if not cm_utils.is_active(self.at_date, part['part'].start_date, part['part'].stop_date):
                 continue
-            huk = k.upper()
+            huk = k
             hookup_dict['hookup'][huk] = {}
             pols_to_do = self.__get_pols_to_do(part, port_query)
             for pol in pols_to_do:

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -120,7 +120,7 @@ class Hookup:
         -----------
         hpn_list:  list of input hera part numbers (whole or first part thereof)
                    may be one of the following string(s):
-                                     'cached':  return the actual dict from cache file
+                        'cached':  return the actual dict from cache file
                    if there are any non-HH items in list, it defaults to force_specific
         rev:  the revision number or descriptor
         port_query:  a specifiable port name to follow or 'all',  default is 'all'.

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -78,12 +78,14 @@ class Hookup:
 
     def set_hookup_cache(self, force_new=False, provided_hookup=None, reset_cache=False):
         """
-        Reads in the appropriate hookup cache file if needed.
-        If new one is needed, it re-writes the cache file.
+        Determines action regarding using an existing cache file or writing and using a new one.
+        If force_new is set, it automatically writes/uses a new one.
+        If reset_cache is set, this only sets the cache file to None (looked at first)
+        if provided_hookup is provided, it sets the internal cache hookup dict to this.
 
         Parameters
         -----------
-        force_new:  boolean to force a new read as opposed to using (valid) file.
+        force_new:  boolean to force a new read as opposed to using file.
         provided_hookup:  will set the cached_hookup_dict to this, if present (only does this)
         reset_cache:  will reset cached_hookup_dict to None, if True (only does this)
         """
@@ -183,7 +185,7 @@ class Hookup:
                      exact_match=False, show_levels=False):
         """
         This gets called by the get_hookup wrapper if the database is to be read.
-        It is the full original method.
+        It is the full original method that was used prior to the cache file wrapper stuff.
         """
         # Get all the appropriate parts
         parts = self.handling.get_part_dossier(hpn_list=hpn_list, rev=rev,
@@ -195,12 +197,11 @@ class Hookup:
         for k, part in parts.iteritems():
             if not cm_utils.is_active(self.at_date, part['part'].start_date, part['part'].stop_date):
                 continue
-            huk = k
-            hookup_dict['hookup'][huk] = {}
+            hookup_dict['hookup'][k] = {}
             pols_to_do = self.__get_pols_to_do(part, port_query)
             for pol in pols_to_do:
-                hookup_dict['hookup'][huk][pol] = self.__follow_hookup_stream(part['part'].hpn, part['part'].hpn_rev, pol)
-                part_types_found = self.__get_part_types_found(hookup_dict['hookup'][huk][pol], part_types_found)
+                hookup_dict['hookup'][k][pol] = self.__follow_hookup_stream(part['part'].hpn, part['part'].hpn_rev, pol)
+                part_types_found = self.__get_part_types_found(hookup_dict['hookup'][k][pol], part_types_found)
         # Add other information in to the hookup_dict
         hookup_dict['columns'], hookup_dict['parts_epoch'] = self.__get_column_headers(part_types_found)
         if len(hookup_dict['columns']):

--- a/hera_mc/sys_handling.py
+++ b/hera_mc/sys_handling.py
@@ -31,7 +31,6 @@ class Handling:
             self.session = db.sessionmaker()
         else:
             self.session = session
-        self.hookup_list_to_cache = hookup_list_to_cache
         self.geo = geo_handling.Handling(self.session)
         self.H = None
 

--- a/hera_mc/sys_handling.py
+++ b/hera_mc/sys_handling.py
@@ -78,7 +78,7 @@ class Handling:
 
         raise ValueError('Too many open dubitable lists ({}).'.format(len(fnd)))
 
-    def get_all_fully_connected_at_date(self, at_date, station_types_to_check='HH'):
+    def get_all_fully_connected_at_date(self, at_date, station_types_to_check=['HH']):
         """
         Returns a list of dictionaries of all of the locations fully connected at_date
         have station_types in station_types_to_check.  The dictonary is defined in
@@ -103,21 +103,28 @@ class Handling:
         Parameters
         -----------
         at_date:  date to check for connections
-        station_types_to_check:  list of station types to limit check, or 'all' [default 'all']
-                                 note that if it is not ['HH'] it will re-read the database and
-                                 not use the cache file.
+        station_types_to_check:  list of station types to check, or 'all' [default ['HH']]
+                                 it can either be the prefix or the "Name" (e.g. 'herahex')
+                                 note that if it is not only ['HH'] it will re-read the database.
         """
         at_date = cm_utils.get_astropytime(at_date)
         self.H = cm_hookup.Hookup(at_date, self.session)
         self.geo.get_station_types()
+        if type(station_types_to_check) == str:
+            if station_types_to_check.lower() == 'all':
+                station_types_to_check = self.geo.station_types.keys()
+            else:
+                station_types_to_check = [station_types_to_check]
+        if type(station_types_to_check) != list:
+            raise ValueError('Invalid station_type request {}'.format(station_types_to_check))
+        station_types_to_check = [x.lower() for x in station_types_to_check]
         station_conn = []
         for k, stn_type in self.geo.station_types.iteritems():
-            if station_types_to_check != 'all' and k not in station_types_to_check:
-                continue
-            for stn in stn_type['Stations']:
-                station_dict = self.get_fully_connected_location_at_date(stn=stn, at_date=at_date)
-                if len(station_dict.keys()) > 1:
-                    station_conn.append(station_dict)
+            if k.lower() in station_types_to_check or stn_type['Name'].lower() in station_types_to_check:
+                for stn in stn_type['Stations']:
+                    station_dict = self.get_fully_connected_location_at_date(stn=stn, at_date=at_date)
+                    if len(station_dict.keys()) > 0:
+                        station_conn.append(station_dict)
         self.H = None  # Reset back in case gets called again outside of this method.
         return station_conn
 
@@ -167,7 +174,7 @@ class Handling:
             corr = cm_hookup.get_parts_from_hookup(corr_name, hud)[k]
             fnd_list = self.geo.get_location([stn[0]], at_date, station_types=self.geo.station_types)
             if not len(fnd_list):
-                return station_dict
+                return {}
             if len(fnd_list) > 1:
                 print("More than one part found:  ", str(fnd))
                 print("Setting to first to continue.")
@@ -219,7 +226,7 @@ class Handling:
         cm_h = cm_handling.Handling(session=self.session)
         cm_version = cm_h.get_cm_version()
         cofa_loc = self.geo.cofa()[0]
-        stations_conn = self.get_all_fully_connected_at_date(at_date='now')
+        stations_conn = self.get_all_fully_connected_at_date(at_date='now', station_types_to_check=['HH'])
         ant_nums = []
         stn_names = []
         stn_types = []

--- a/hera_mc/sys_handling.py
+++ b/hera_mc/sys_handling.py
@@ -21,7 +21,7 @@ class Handling:
     Class to allow various manipulations of correlator inputs etc
     """
 
-    def __init__(self, session=None, hookup_list_to_cache=['HH']):
+    def __init__(self, session=None):
         """
         session: session on current database. If session is None, a new session
                  on the default database is created and used.
@@ -78,7 +78,7 @@ class Handling:
 
         raise ValueError('Too many open dubitable lists ({}).'.format(len(fnd)))
 
-    def get_all_fully_connected_at_date(self, at_date, station_types_to_check='all'):
+    def get_all_fully_connected_at_date(self, at_date, station_types_to_check='HH'):
         """
         Returns a list of dictionaries of all of the locations fully connected at_date
         have station_types in station_types_to_check.  The dictonary is defined in
@@ -104,9 +104,11 @@ class Handling:
         -----------
         at_date:  date to check for connections
         station_types_to_check:  list of station types to limit check, or 'all' [default 'all']
+                                 note that if it is not ['HH'] it will re-read the database and
+                                 not use the cache file.
         """
         at_date = cm_utils.get_astropytime(at_date)
-        self.H = cm_hookup.Hookup(at_date, self.session, self.hookup_list_to_cache)
+        self.H = cm_hookup.Hookup(at_date, self.session)
         self.geo.get_station_types()
         station_conn = []
         for k, stn_type in self.geo.station_types.iteritems():
@@ -148,8 +150,8 @@ class Handling:
         if self.H is not None:
             H = self.H
         else:
-            H = cm_hookup.Hookup(at_date, self.session, self.hookup_list_to_cache)
-        hud = H.get_hookup([stn], exact_match=True)
+            H = cm_hookup.Hookup(at_date, self.session)
+        hud = H.get_hookup(hpn_list=[stn], exact_match=True)
         station_dict = {}
         fc = cm_revisions.get_full_revision_keys(stn, hud)
         if len(fc) == 1:
@@ -275,8 +277,8 @@ class Handling:
             dict of {pol:(rcvr location,pam #)}
         """
         pams = {}
-        H = cm_hookup.Hookup(at_date, self.session, self.hookup_list_to_cache)
-        hud = H.get_hookup([stn], exact_match=True)
+        H = cm_hookup.Hookup(at_date, self.session)
+        hud = H.get_hookup(hpn_list=[stn], exact_match=True)
         fc = cm_revisions.get_full_revision_keys(stn, hud)
         if len(fc) == 1:
             k = fc[0][0]
@@ -290,7 +292,7 @@ class Handling:
         import os.path
         output_file = os.path.expanduser('~/.hera_mc/sys_conn_tmp.html')
         location_on_paper1 = 'paper1:/home/davidm/local/src/rails-paper/public'
-        H = cm_hookup.Hookup('now', self.session, self.hookup_list_to_cache)
+        H = cm_hookup.Hookup('now', self.session)
         hookup_dict = H.get_hookup(hpn_list=hlist, rev=rev, port_query='all',
                                    exact_match=exact_match, show_levels=True,
                                    force_new=force_new_hookup_dict, force_specific=False)

--- a/hera_mc/sys_handling.py
+++ b/hera_mc/sys_handling.py
@@ -294,7 +294,7 @@ class Handling:
 
     def publish_summary(self, hlist=['HH'], rev='A', exact_match=False,
                         hookup_cols=['station', 'front-end', 'cable-post-amp(in)', 'post-amp', 'cable-container', 'f-engine', 'level'],
-                        force_new_hookup_dict=True):
+                        force_new_hookup_dict=False):
         import os.path
         output_file = os.path.expanduser('~/.hera_mc/sys_conn_tmp.html')
         location_on_paper1 = 'paper1:/home/davidm/local/src/rails-paper/public'

--- a/hera_mc/tests/test_sys_handling.py
+++ b/hera_mc/tests/test_sys_handling.py
@@ -23,7 +23,7 @@ class TestSys(TestHERAMC):
 
     def setUp(self):
         super(TestSys, self).setUp()
-        self.h = sys_handling.Handling(self.test_session, hookup_list_to_cache=['force_specific'])
+        self.h = sys_handling.Handling(self.test_session)
 
     def test_ever_fully_connected(self):
         now_list = self.h.get_all_fully_connected_at_date(at_date='now')
@@ -88,8 +88,8 @@ class TestSys(TestHERAMC):
 
     def test_correlator_levels(self):
         at_date = cm_utils.get_astropytime('2017-07-03')
-        H = cm_hookup.Hookup(at_date, self.test_session, hookup_list_to_cache=['force_specific'])
-        hu = H.get_hookup(['HH23'], 'A', 'all', exact_match=True, show_levels=True)
+        H = cm_hookup.Hookup(at_date, self.test_session)
+        hu = H.get_hookup(['HH23'], 'A', 'all', exact_match=True, show_levels=True, force_new=True)
         hh23level = float(hu['levels']['HH23:A']['e'])
         self.assertEqual(type(hh23level), float)
         # Now get some failures
@@ -107,7 +107,7 @@ class TestSys(TestHERAMC):
             part.manufacture_number = self.test_mfg
             part.start_gpstime = self.test_time
             self.test_session.add(part)
-        self.test_session.commit()
+            self.test_session.commit()
         connection = part_connect.Connections()
         connection.upstream_part = self.test_hpn[0]
         connection.up_part_rev = self.test_rev
@@ -118,7 +118,7 @@ class TestSys(TestHERAMC):
         connection.start_gpstime = self.test_time
         self.test_session.add(connection)
         self.test_session.commit()
-        hu = H.get_hookup(['test_part1'], 'Q', 'all', exact_match=True, show_levels=True)
+        hu = H.get_hookup(['test_part1'], 'Q', 'all', exact_match=True, show_levels=True, force_specific=True)
         tplevel = hu['levels']['test_part1:Q']['e']
         print(tplevel)
         self.assertEqual(tplevel, '-')


### PR DESCRIPTION
This (starts) to address the issue of the (unexpected) frequent rewriting of the cache file.

It corrects an undesirable item where the system requests-to-hookup addressed the database instead of the cache file.  This _seems_ related to the cache rewriting issue, but I'm not sure (I can't point to the guilty code).  I've added a cm_log entry when it gets rewritten to help diagnose for the future.