### PR TITLE
Make the obsids optional on Librarian files.

### DIFF
--- a/Docs/mc_definition.tex
+++ b/Docs/mc_definition.tex
@@ -212,7 +212,7 @@ bandwidth\_mps & float & bandwidth to remote in Mb/s, 15 minute average \\\hline
 \hline
  column & type & description \\ [0.5ex]  \hline\hline
 \textbf{filename} & string & name of file created \\ \hline
-\textit{obsid} & long integer & observation identifier, foreign key into hera\_obs table \\ \hline
+\textit{obsid} & long integer & observation identifier, foreign key into hera\_obs table. Can be null. \\ \hline
 time & long & file creation time in floor(gps seconds)\\ \hline
 size\_gb & float & file size in gigabytes \\ \hline
 \end{tabular}

--- a/alembic/versions/c9a1ff35c6ed_make_librarian_file_obsids_optional.py
+++ b/alembic/versions/c9a1ff35c6ed_make_librarian_file_obsids_optional.py
@@ -1,0 +1,25 @@
+"""Make Librarian file obsids optional.
+
+Revision ID: c9a1ff35c6ed
+Revises: f29adafca107
+Create Date: 2017-12-15 18:50:37.889271+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'c9a1ff35c6ed'
+down_revision = 'f29adafca107'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('lib_files', 'obsid', existing_type=sa.BIGINT(), nullable=True)
+
+
+def downgrade():
+    # NOTE this likely won't work unless we delete the rows that actually have
+    # null obsids.
+    op.alter_column('lib_files', 'obsid', existing_type=sa.BIGINT(), nullable=False)

--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -52,6 +52,8 @@ def MCDeclarativeBase_close(self, other):
             if not np.all(self_c == other_c):
                 print('column {col} is an int-like array, values are not equal'.format(col=c))
                 return False
+        elif self_c is None and other_c is None:
+            pass # nullable columns, both null
         else:
             if hasattr(self, 'tols') and c.name in self.tols.keys():
                 atol = self.tols[c.name]['atol']

--- a/hera_mc/librarian.py
+++ b/hera_mc/librarian.py
@@ -208,12 +208,14 @@ class LibFiles(MCDeclarativeBase):
 
     filename: name of file created (String). Primary_key
     obsid: observation obsid (Long). Foreign key into Observation table
+      Null values allowed for maintenance files not associated with
+      particular observations.
     time: time this file was created in floor(gps seconds) (BigInteger)
     size_gb: file size in gb (Float)
     """
     __tablename__ = 'lib_files'
     filename = Column(String(256), primary_key=True)
-    obsid = Column(BigInteger, ForeignKey('hera_obs.obsid'), nullable=False)
+    obsid = Column(BigInteger, ForeignKey('hera_obs.obsid'), nullable=True)
     time = Column(BigInteger, nullable=False)
     size_gb = Column(Float, nullable=False)
 
@@ -226,8 +228,10 @@ class LibFiles(MCDeclarativeBase):
         ------------
         filename: string
             name of file created
-        obsid: long
-            observation obsid (Foreign key into Observation)
+        obsid: long or None
+            observation obsid (Foreign key into Observation), or None if
+            this file is a maintenance file not associated with a
+            particular observation.
         time: astropy time object
             time file was created
         size_gb: float

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -503,8 +503,8 @@ class MCSession(Session):
         ------------
         filename: string
             name of file created
-        obsid: long
-            observation obsid (Foreign key into Observation)
+        obsid: long or None
+            optional observation obsid (Foreign key into Observation)
         time: astropy time object
             time file was created
         size_gb: float

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -285,6 +285,28 @@ class TestLibrarian(TestHERAMC):
         for i in range(0, len(result_obsid)):
             self.assertTrue(result_obsid[i].isclose(result_all[i]))
 
+    def test_lib_file_null_obsid(self):
+        self.test_session.add_obs(*self.observation_values)
+
+        time = Time.now()
+        file_values = ['nullobsfile', None, time, 1.234]
+        self.test_session.add_lib_file(*file_values)
+
+        expected = LibFiles(
+            filename = file_values[0],
+            obsid = None,
+            time = int(floor(time.gps)),
+            size_gb = file_values[3],
+        )
+
+        result = self.test_session.get_lib_files(filename=file_values[0])
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0].isclose(expected))
+
+        # Clean up so as not to step on toes of `test_add_lib_file()` test.
+        self.test_session.delete(result[0])
+        self.test_session.commit()
+
     def test_errors_add_lib_file(self):
         self.test_session.add_obs(*self.observation_values)
         obs_result = self.test_session.get_obs()


### PR DESCRIPTION
The Librarian is going to start having some files without obsids, for tracking maintenance files (e.g. weekly database backups) that are not tied to data-taking. M&C should still know about such files, though, so it needs to learn to deal with them.