### PR TITLE
Add support for task_name in get_rtp_task_resource_record

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -739,7 +739,8 @@ class MCSession(Session):
         self.add(RTPTaskResourceRecord.create(obsid, task_name, start_time, stop_time,
                                               max_memory, avg_cpu_load))
 
-    def get_rtp_task_resource_record(self, starttime, stoptime=None, obsid=None):
+    def get_rtp_task_resource_record(self, starttime, stoptime=None, obsid=None,
+                                     task_name=None):
         """
         Get rtp_task_resource_record from the M&C database.
 
@@ -752,6 +753,8 @@ class MCSession(Session):
             starttime will be returned.
         obsid: long
             obsid to get records for. If none, all obsid will be included
+        task_name: string
+            task_name to get records for. If none, all tasks will be included
 
         Returns:
         -----------
@@ -760,9 +763,18 @@ class MCSession(Session):
         """
         from .rtp import RTPTaskResourceRecord
 
-        return self._time_filter(RTPTaskResourceRecord, 'start_time', starttime,
-                                 stoptime=stoptime, filter_column='obsid',
-                                 filter_value=obsid)
+        if task_name is None:
+            return self._time_filter(RTPTaskResourceRecord, 'start_time', starttime,
+                                     stoptime=stoptime, filter_column='obsid',
+                                     filter_value=obsid)
+        elif obsid is None:
+            return self._time_filter(RTPTaskResourceRecord, 'start_time', starttime,
+                                     stoptime=stoptime, filter_column='task_name',
+                                     filter_value=task_name)
+        else:
+            return self.query(RTPTaskResourceRecord).filter(
+                RTPTaskResourceRecord.obsid == obsid,
+                RTPTaskResourceRecord.task_name == task_name).all()
 
     def add_paper_temps(self, read_time, temp_list):
         """
@@ -924,7 +936,6 @@ class MCSession(Session):
 
         for item in q:
             print('{}\t{}'.format(item.astropy_time, item.value), file=files[item.variable])
-
 
     def add_roach_temperature(self, time, roach, ambient_temp, inlet_temp,
                               outlet_temp, fpga_temp, ppc_temp):

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -405,6 +405,8 @@ class TestRTP(TestHERAMC):
         self.assertRaises(ValueError, self.test_session.get_rtp_task_resource_record,
                           task_name=self.task_resource_columns['task_name'])
 
+        self.assertRaises(ValueError, self.test_session.get_rtp_task_resource_record)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -51,7 +51,6 @@ class TestRTP(TestHERAMC):
                                      16.2, 1.01]
         self.task_resource_columns = dict(zip(self.task_resource_names, self.task_resource_values))
 
-
     def test_add_rtp_status(self):
         self.test_session.add_rtp_status(*self.status_values)
 
@@ -295,9 +294,24 @@ class TestRTP(TestHERAMC):
         exp_columns['stop_time'] = int(floor(exp_columns['stop_time'].gps))
         expected = RTPTaskResourceRecord(**exp_columns)
 
-        result = self.test_session.get_rtp_task_resource_record(self.task_resource_columns['start_time'] -
-                                                                TimeDelta(2, format='sec'),
-                                                                obsid=self.record_columns['obsid'])
+        result = self.test_session.get_rtp_task_resource_record(
+            self.task_resource_columns['start_time'] - TimeDelta(2, format='sec'),
+            obsid=self.task_resource_columns['obsid'])
+        self.assertEqual(len(result), 1)
+        result = result[0]
+        self.assertTrue(result.isclose(expected))
+
+        result = self.test_session.get_rtp_task_resource_record(
+            self.task_resource_columns['start_time'] - TimeDelta(2, format='sec'),
+            task_name=self.task_resource_columns['task_name'])
+        self.assertEqual(len(result), 1)
+        result = result[0]
+        self.assertTrue(result.isclose(expected))
+
+        result = self.test_session.get_rtp_task_resource_record(
+            self.task_resource_columns['start_time'] - TimeDelta(2, format='sec'),
+            obsid=self.task_resource_columns['obsid'],
+            task_name=self.task_resource_columns['task_name'])
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
@@ -342,6 +356,7 @@ class TestRTP(TestHERAMC):
 
         self.test_session.add_rtp_task_resource_record(*self.task_resource_values)
         self.assertRaises(ValueError, self.test_session.get_rtp_process_record, 1, 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a small tweak to the method to allow for filtering on either task_name or obsid or both.