### PR TITLE
Use aipy instead of pyuvdata to query file metadata

### DIFF
--- a/scripts/mc_add_observation.py
+++ b/scripts/mc_add_observation.py
@@ -3,31 +3,35 @@
 # Copyright 2017 the HERA Collaboration
 # Licensed under the 2-clause BSD license.
 
-import argparse,pyuvdata,aipy
+import argparse, aipy
 from hera_mc.observations import Observation
 from hera_mc import mc
-from astropy.time import Time,TimeDelta
+from astropy.time import Time, TimeDelta
+
 a = mc.get_mc_argument_parser()
 a.description = """Read the obsid from a file and create a record in M&C."""
-a.add_argument('files',metavar='file',type=str,nargs='*',default=[],
-        help='*.uv files to extract')
+a.add_argument('files', metavar='file', type=str, nargs='*', default=[],
+               help='*.uv files to extract')
 args = a.parse_args()
 db = mc.connect_to_mc_db(args)
 
 
 for uvfile in args.files:
-    #we need aipy to read the stopt and duration because everything is aweful
-    #but first tell AIPY we're allowed to read these variables
+    # we need aipy to read the stopt and duration because everything is awful
+    # but first tell AIPY we're allowed to read these variables
     aipy.miriad.itemtable['stopt'] = 'd'
     aipy.miriad.itemtable['duration'] = 'd'
     UV = aipy.miriad.UV(uvfile)
-    stoptime = Time(UV['stopt'],scale='utc',format='gps')
-
-    UVData = pyuvdata.UVData()
-    UVData.read_miriad(uvfile)
-    obsid = UVData.extra_keywords['obsid']
-    starttime = Time(UVData.extra_keywords['startt'],scale='utc',format='gps')
+    obsid = UV['obsid']
 
     with db.sessionmaker() as session:
+        obs = session.get_obs(obsid)
+        if len(obs) > 0:
+            print("observation {obs} already in M&C, skipping".format(obs=obsid))
+            continue
+        stoptime = Time(UV['stopt'], scale='utc', format='gps')
+        starttime = Time(UV['startt'], scale='utc', format='gps')
+        print("Inserting obsid into M&C:" + str(UV['obsid']))
+
         session.add_obs(starttime, stoptime, obsid)
     session.commit()


### PR DESCRIPTION
This PR uses `aipy` instead of `pyuvdata` to query the metadata necessary for uploading files to the librarian. This is necessary on paper1.