### PR TITLE
Add most_recent filter

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -48,7 +48,7 @@ class MCSession(Session):
         return db_time
 
     def _time_filter(self, table_class, time_column, most_recent=None,
-                     starttime=startime, stoptime=None,
+                     starttime=None, stoptime=None,
                      filter_column=None, filter_value=None):
         '''
         A helper method to fiter entries by time. Used by most get methods
@@ -290,7 +290,7 @@ class MCSession(Session):
                                      network_bandwidth_mbs=network_bandwidth_mbs))
 
     def get_server_status(self, subsystem, most_recent=None,
-                          starttime=starttime, stoptime=None, hostname=None):
+                          starttime=None, stoptime=None, hostname=None):
         """
         Get subsystem server_status record(s) from the M&C database.
 

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -86,6 +86,9 @@ class MCSession(Session):
         if starttime is None and most_recent is None:
             most_recent = True
 
+        if not isinstance(most_recent, (type(None), bool)):
+            raise TypeError('most_recent must be None or a boolean')
+
         if not most_recent:
             if starttime is None:
                 raise ValueError('starttime must be specified if most_recent is False')

--- a/hera_mc/tests/test_node.py
+++ b/hera_mc/tests/test_node.py
@@ -132,11 +132,6 @@ class TestNodeSensor(TestHERAMC):
                           'foo', 1, top_sensor_temp, middle_sensor_temp,
                           bottom_sensor_temp, humidity_sensor_temp, humidity)
 
-        self.assertRaises(ValueError, node.NodeSensor, 'foo', node=1,
-                          top_sensor_temp=30., middle_sensor_temp=31.98,
-                          bottom_sensor_temp=41., humidity_sensor_temp=33.89,
-                          humidity=32.5)
-
     def test_add_node_sensor_readings_from_nodecontrol(self):
 
         if is_onsite():
@@ -244,11 +239,6 @@ class TestNodePowerStatus(TestHERAMC):
         self.assertRaises(ValueError, self.test_session.add_node_power_status,
                           'foo', 1, snap_relay_powered, snap0_powered, snap1_powered,
                           snap2_powered, snap3_powered, fem_powered, pam_powered)
-
-        self.assertRaises(ValueError, node.NodePowerStatus, time='foo', node=1,
-                          snap_relay_powered=True, snap0_powered=False,
-                          snap1_powered=True, snap2_powered=False,
-                          snap3_powered=False, pam_powered=True, fem_powered=True)
 
     def test_add_node_power_status_from_nodecontrol(self):
 

--- a/hera_mc/tests/test_node.py
+++ b/hera_mc/tests/test_node.py
@@ -122,6 +122,21 @@ class TestNodeSensor(TestHERAMC):
         result_most_recent = self.test_session.get_node_sensor_readings(most_recent=True)
         self.assertEqual(result_most_recent, result)
 
+    def test_sensor_reading_errors(self):
+        top_sensor_temp = node_sensor_example_dict['1']['temp_top']
+        middle_sensor_temp = node_sensor_example_dict['1']['temp_mid']
+        bottom_sensor_temp = node_sensor_example_dict['1']['temp_bot']
+        humidity_sensor_temp = node_sensor_example_dict['1']['temp_humid']
+        humidity = node_sensor_example_dict['1']['humid']
+        self.assertRaises(ValueError, self.test_session.add_node_sensor_readings,
+                          'foo', 1, top_sensor_temp, middle_sensor_temp,
+                          bottom_sensor_temp, humidity_sensor_temp, humidity)
+
+        self.assertRaises(ValueError, node.NodeSensor, 'foo', node=1,
+                          top_sensor_temp=30., middle_sensor_temp=31.98,
+                          bottom_sensor_temp=41., humidity_sensor_temp=33.89,
+                          humidity=32.5)
+
     def test_add_node_sensor_readings_from_nodecontrol(self):
 
         if is_onsite():
@@ -217,6 +232,23 @@ class TestNodePowerStatus(TestHERAMC):
 
         result_most_recent = self.test_session.get_node_power_status()
         self.assertEqual(result_most_recent, result)
+
+    def test_node_power_status_errors(self):
+        snap_relay_powered = node_power_example_dict['1']['power_snap_relay']
+        snap0_powered = node_power_example_dict['1']['power_snap_0']
+        snap1_powered = node_power_example_dict['1']['power_snap_1']
+        snap2_powered = node_power_example_dict['1']['power_snap_2']
+        snap3_powered = node_power_example_dict['1']['power_snap_3']
+        pam_powered = node_power_example_dict['1']['power_pam']
+        fem_powered = node_power_example_dict['1']['power_fem']
+        self.assertRaises(ValueError, self.test_session.add_node_power_status,
+                          'foo', 1, snap_relay_powered, snap0_powered, snap1_powered,
+                          snap2_powered, snap3_powered, fem_powered, pam_powered)
+
+        self.assertRaises(ValueError, node.NodePowerStatus, time='foo', node=1,
+                          snap_relay_powered=True, snap0_powered=False,
+                          snap1_powered=True, snap2_powered=False,
+                          snap3_powered=False, pam_powered=True, fem_powered=True)
 
     def test_add_node_power_status_from_nodecontrol(self):
 

--- a/hera_mc/tests/test_node.py
+++ b/hera_mc/tests/test_node.py
@@ -63,7 +63,7 @@ class TestNodeSensor(TestHERAMC):
                                    top_sensor_temp=30., middle_sensor_temp=31.98,
                                    bottom_sensor_temp=41., humidity_sensor_temp=33.89,
                                    humidity=32.5)
-        result = self.test_session.get_node_sensor_readings(t1 - TimeDelta(3.0, format='sec'))
+        result = self.test_session.get_node_sensor_readings(starttime=t1 - TimeDelta(3.0, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
@@ -79,17 +79,21 @@ class TestNodeSensor(TestHERAMC):
                                                    humidity_sensor_temp,
                                                    humidity)
 
-        result = self.test_session.get_node_sensor_readings(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_sensor_readings(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                             nodeID=1)
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result = self.test_session.get_node_sensor_readings(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_sensor_readings(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                             stoptime=t1)
         self.assertEqual(len(result), 2)
 
-        result = self.test_session.get_node_sensor_readings(t1 + TimeDelta(200.0, format='sec'))
+        result_most_recent = self.test_session.get_node_sensor_readings()
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result_most_recent, result)
+
+        result = self.test_session.get_node_sensor_readings(starttime=t1 + TimeDelta(200.0, format='sec'))
         self.assertEqual(result, [])
 
     def test_create_sensor_readings(self):
@@ -100,7 +104,7 @@ class TestNodeSensor(TestHERAMC):
             self.test_session.add(obj)
 
         t1 = Time(1512770942.726777, format='unix')
-        result = self.test_session.get_node_sensor_readings(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_sensor_readings(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                             nodeID=1)
 
         expected = node.NodeSensor(time=int(floor(t1.gps)), node=1,
@@ -111,9 +115,12 @@ class TestNodeSensor(TestHERAMC):
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result = self.test_session.get_node_sensor_readings(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_sensor_readings(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                             stoptime=t1 + TimeDelta(5.0, format='sec'))
         self.assertEqual(len(result), 3)
+
+        result_most_recent = self.test_session.get_node_sensor_readings(most_recent=True)
+        self.assertEqual(result_most_recent, result)
 
     def test_add_node_sensor_readings_from_nodecontrol(self):
 
@@ -122,7 +129,7 @@ class TestNodeSensor(TestHERAMC):
 
             self.test_session.add_node_sensor_readings_from_nodecontrol()
             result = self.test_session.get_node_sensor_readings(
-                Time.now() - TimeDelta(120.0, format='sec'),
+                starttime=Time.now() - TimeDelta(120.0, format='sec'),
                 stoptime=Time.now() + TimeDelta(120.0, format='sec'))
             self.assertEqual(len(result), len(node_list))
 
@@ -150,34 +157,38 @@ class TestNodePowerStatus(TestHERAMC):
                                         snap1_powered=True, snap2_powered=False,
                                         snap3_powered=False, pam_powered=True,
                                         fem_powered=True)
-        result = self.test_session.get_node_power_status(t1 - TimeDelta(3.0, format='sec'))
+        result = self.test_session.get_node_power_status(starttime=t1 - TimeDelta(3.0, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        snap_relay_powered = node_power_example_dict['1']['power_snap_relay']
-        snap0_powered = node_power_example_dict['1']['power_snap_0']
-        snap1_powered = node_power_example_dict['1']['power_snap_1']
-        snap2_powered = node_power_example_dict['1']['power_snap_2']
-        snap3_powered = node_power_example_dict['1']['power_snap_3']
-        pam_powered = node_power_example_dict['1']['power_pam']
-        fem_powered = node_power_example_dict['1']['power_fem']
+        snap_relay_powered = node_power_example_dict['2']['power_snap_relay']
+        snap0_powered = node_power_example_dict['2']['power_snap_0']
+        snap1_powered = node_power_example_dict['2']['power_snap_1']
+        snap2_powered = node_power_example_dict['2']['power_snap_2']
+        snap3_powered = node_power_example_dict['2']['power_snap_3']
+        pam_powered = node_power_example_dict['2']['power_pam']
+        fem_powered = node_power_example_dict['2']['power_fem']
         self.test_session.add_node_power_status(t1, 2, snap_relay_powered,
                                                 snap0_powered, snap1_powered,
                                                 snap2_powered, snap3_powered,
                                                 fem_powered, pam_powered)
 
-        result = self.test_session.get_node_power_status(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_power_status(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                          nodeID=1)
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result = self.test_session.get_node_power_status(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_power_status(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                          stoptime=t1)
         self.assertEqual(len(result), 2)
 
-        result = self.test_session.get_node_power_status(t1 + TimeDelta(200.0, format='sec'))
+        result_most_recent = self.test_session.get_node_power_status()
+        self.assertEqual(len(result_most_recent), 2)
+        self.assertEqual(result_most_recent, result)
+
+        result = self.test_session.get_node_power_status(starttime=t1 + TimeDelta(200.0, format='sec'))
         self.assertEqual(result, [])
 
     def test_create_power_status(self):
@@ -188,7 +199,7 @@ class TestNodePowerStatus(TestHERAMC):
             self.test_session.add(obj)
 
         t1 = Time(1512770942.726777, format='unix')
-        result = self.test_session.get_node_power_status(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_power_status(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                          nodeID=1)
 
         expected = node.NodePowerStatus(time=int(floor(t1.gps)), node=1,
@@ -200,9 +211,12 @@ class TestNodePowerStatus(TestHERAMC):
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result = self.test_session.get_node_power_status(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_node_power_status(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                          stoptime=t1 + TimeDelta(5.0, format='sec'))
         self.assertEqual(len(result), 3)
+
+        result_most_recent = self.test_session.get_node_power_status()
+        self.assertEqual(result_most_recent, result)
 
     def test_add_node_power_status_from_nodecontrol(self):
 
@@ -210,7 +224,7 @@ class TestNodePowerStatus(TestHERAMC):
             node_list = node.get_node_list()
 
             self.test_session.add_node_power_status_from_nodecontrol()
-            result = self.test_session.get_node_power_status(Time.now() - TimeDelta(120.0, format='sec'),
+            result = self.test_session.get_node_power_status(starttime=Time.now() - TimeDelta(120.0, format='sec'),
                                                              stoptime=Time.now() + TimeDelta(120.0, format='sec'))
             self.assertEqual(len(result), len(node_list))
 

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -65,8 +65,11 @@ class TestObservation(TestHERAMC):
         t4 = t2 + TimeDelta(10 * 60., format='sec')
         self.test_session.add_obs(t3, t4, utils.calculate_obsid(t3))
 
-        result_mult = self.test_session.get_obs_by_time(t1, stoptime=t4)
+        result_mult = self.test_session.get_obs_by_time(starttime=t1, stoptime=t4)
         self.assertEqual(len(result_mult), 2)
+
+        result_most_recent = self.test_session.get_obs_by_time(most_recent=True)
+        self.assertEqual(result_most_recent[0], result_mult[1])
 
         result_orig = self.test_session.get_obs(obsid=obsid)
         self.assertEqual(len(result_orig), 1)

--- a/hera_mc/tests/test_observations.py
+++ b/hera_mc/tests/test_observations.py
@@ -84,6 +84,8 @@ class TestObservation(TestHERAMC):
         self.assertRaises(ValueError, self.test_session.add_obs, t1, t2, 'foo')
         self.assertRaises(ValueError, utils.calculate_obsid, 'foo')
         self.assertRaises(ValueError, self.test_session.add_obs, t1, t2, utils.calculate_obsid(t1) + 2)
+        self.assertRaises(TypeError, self.test_session.get_obs_by_time, most_recent=t1)
+        self.assertRaises(TypeError, self.test_session.get_obs_by_time, t1)
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -24,7 +24,7 @@ class TestRTP(TestHERAMC):
     def setUp(self):
         super(TestRTP, self).setUp()
 
-        time = Time.now()
+        time = Time.now() - TimeDelta(30 * 60, format='sec')
         obsid = utils.calculate_obsid(time)
         self.observation_names = ['starttime', 'stoptime', 'obsid']
         self.observation_values = [time, time + TimeDelta(10 * 60, format='sec'),
@@ -60,7 +60,7 @@ class TestRTP(TestHERAMC):
         exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = RTPStatus(**exp_columns)
 
-        result = self.test_session.get_rtp_status(self.status_columns['time']
+        result = self.test_session.get_rtp_status(starttime=self.status_columns['time']
                                                   - TimeDelta(2, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
@@ -75,25 +75,30 @@ class TestRTP(TestHERAMC):
                                          self.status_columns['num_processes'],
                                          self.status_columns['restart_hours_elapsed'] + 5. / 60.)
 
-        result_mult = self.test_session.get_rtp_status(self.status_columns['time']
+        result_mult = self.test_session.get_rtp_status(starttime=self.status_columns['time']
                                                        - TimeDelta(2, format='sec'),
                                                        stoptime=new_status_time)
         self.assertEqual(len(result_mult), 2)
 
-        result2 = self.test_session.get_rtp_status(new_status_time
+        result2 = self.test_session.get_rtp_status(starttime=new_status_time
                                                    - TimeDelta(2, format='sec'))
         self.assertEqual(len(result2), 1)
         result2 = result2[0]
         self.assertFalse(result2.isclose(expected))
+
+        result_most_recent = self.test_session.get_rtp_status()
+        self.assertEqual(len(result_most_recent), 1)
+        result_most_recent = result_most_recent[0]
+        self.assertTrue(result2.isclose(result_most_recent))
 
     def test_errors_rtp_status(self):
         self.assertRaises(ValueError, self.test_session.add_rtp_status, 'foo',
                           *self.status_values[1:])
 
         self.test_session.add_rtp_status(*self.status_values)
-        self.assertRaises(ValueError, self.test_session.get_rtp_status, 'unhappy')
+        self.assertRaises(ValueError, self.test_session.get_rtp_status, starttime='unhappy')
         self.assertRaises(ValueError, self.test_session.get_rtp_status,
-                          self.status_columns['time'], stoptime='unhappy')
+                          starttime=self.status_columns['time'], stoptime='unhappy')
 
     def test_add_rtp_process_event(self):
         # raise error if try to add process event with unmatched obsid
@@ -111,11 +116,11 @@ class TestRTP(TestHERAMC):
         exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = RTPProcessEvent(**exp_columns)
 
-        result = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                          - TimeDelta(2, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
-        result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result_obsid = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                                - TimeDelta(2, format='sec'),
                                                                obsid=self.event_columns['obsid'])
         self.assertEqual(len(result_obsid), 1)
@@ -133,7 +138,7 @@ class TestRTP(TestHERAMC):
         self.test_session.add_rtp_process_event(new_obsid_time,
                                                 new_obsid,
                                                 self.event_columns['event'])
-        result_obsid = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result_obsid = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                                - TimeDelta(2, format='sec'),
                                                                obsid=self.event_columns['obsid'])
         self.assertEqual(len(result_obsid), 1)
@@ -146,18 +151,26 @@ class TestRTP(TestHERAMC):
                                                 self.event_columns['obsid'],
                                                 new_event)
 
-        result_mult = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result_mult = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                               - TimeDelta(2, format='sec'),
                                                               stoptime=new_event_time)
         self.assertEqual(len(result_mult), 3)
 
-        result_mult_obsid = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result_most_recent = self.test_session.get_rtp_process_event()
+        self.assertEqual(len(result_most_recent), 1)
+        self.assertEqual(result_most_recent[0], result_mult[2])
+
+        result_mult_obsid = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                                     - TimeDelta(2, format='sec'),
                                                                     stoptime=new_event_time,
                                                                     obsid=self.event_columns['obsid'])
         self.assertEqual(len(result_mult_obsid), 2)
 
-        result_new_obsid = self.test_session.get_rtp_process_event(self.event_columns['time']
+        result_obsid_most_recent = self.test_session.get_rtp_process_event(obsid=self.event_columns['obsid'])
+        self.assertEqual(len(result_most_recent), 1)
+        self.assertEqual(result_obsid_most_recent[0], result_mult_obsid[1])
+
+        result_new_obsid = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                                    - TimeDelta(2, format='sec'),
                                                                    obsid=new_obsid)
         self.assertEqual(len(result_new_obsid), 1)
@@ -173,9 +186,9 @@ class TestRTP(TestHERAMC):
                           *self.event_values[1:])
 
         self.test_session.add_rtp_process_event(*self.event_values)
-        self.assertRaises(ValueError, self.test_session.get_rtp_process_event, 'foo')
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_event, starttime='foo')
         self.assertRaises(ValueError, self.test_session.get_rtp_process_event,
-                          self.event_columns['time'], stoptime='bar')
+                          starttime=self.event_columns['time'], stoptime='bar')
 
         # raise error if pass value not in enum
         # self.assertRaises(ValueError, self.test_session.add_rtp_process_event,
@@ -190,11 +203,11 @@ class TestRTP(TestHERAMC):
         self.test_session.add_rtp_process_event(*self.event_values)
         self.test_session.add_rtp_status(*self.status_values)
 
-        status_result = self.test_session.get_rtp_status(self.status_columns['time']
+        status_result = self.test_session.get_rtp_status(starttime=self.status_columns['time']
                                                          - TimeDelta(2, format='sec'))
         self.assertEqual(len(status_result), 1)
         status_result = status_result[0]
-        event_result = self.test_session.get_rtp_process_event(self.event_columns['time']
+        event_result = self.test_session.get_rtp_process_event(starttime=self.event_columns['time']
                                                                - TimeDelta(2, format='sec'))
         self.assertFalse(status_result.isclose(event_result))
 
@@ -214,13 +227,13 @@ class TestRTP(TestHERAMC):
         exp_columns['time'] = int(floor(exp_columns['time'].gps))
         expected = RTPProcessRecord(**exp_columns)
 
-        result = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                           - TimeDelta(2, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
 
-        result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result_obsid = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                                 - TimeDelta(2, format='sec'),
                                                                 obsid=self.record_columns['obsid'])
         self.assertEqual(len(result_obsid), 1)
@@ -238,7 +251,7 @@ class TestRTP(TestHERAMC):
         self.test_session.add_rtp_process_record(new_obsid_time,
                                                  new_obsid,
                                                  *self.record_values[2:11])
-        result_obsid = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result_obsid = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                                 - TimeDelta(2, format='sec'),
                                                                 obsid=self.record_columns['obsid'])
         self.assertEqual(len(result_obsid), 1)
@@ -251,18 +264,26 @@ class TestRTP(TestHERAMC):
                                                  self.record_columns['obsid'],
                                                  new_pipeline, *self.record_values[3:11])
 
-        result_mult = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result_mult = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                                - TimeDelta(2, format='sec'),
                                                                stoptime=new_record_time)
         self.assertEqual(len(result_mult), 3)
 
-        result_mult_obsid = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result_most_recent = self.test_session.get_rtp_process_record()
+        self.assertEqual(len(result_most_recent), 1)
+        self.assertEqual(result_most_recent[0], result_mult[2])
+
+        result_mult_obsid = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                                      - TimeDelta(2, format='sec'),
                                                                      stoptime=new_record_time,
                                                                      obsid=self.record_columns['obsid'])
         self.assertEqual(len(result_mult_obsid), 2)
 
-        result_new_obsid = self.test_session.get_rtp_process_record(self.record_columns['time']
+        result_obsid_most_recent = self.test_session.get_rtp_process_record(obsid=self.record_columns['obsid'])
+        self.assertEqual(len(result_obsid_most_recent), 1)
+        self.assertEqual(result_obsid_most_recent[0], result_mult_obsid[1])
+
+        result_new_obsid = self.test_session.get_rtp_process_record(starttime=self.record_columns['time']
                                                                     - TimeDelta(2, format='sec'),
                                                                     obsid=new_obsid)
         self.assertEqual(len(result_new_obsid), 1)
@@ -280,9 +301,9 @@ class TestRTP(TestHERAMC):
                           *fake_vals)
 
         self.test_session.add_rtp_process_record(*self.record_values)
-        self.assertRaises(ValueError, self.test_session.get_rtp_process_record, 'foo')
+        self.assertRaises(ValueError, self.test_session.get_rtp_process_record, starttime='foo')
         self.assertRaises(ValueError, self.test_session.get_rtp_process_record,
-                          self.record_columns['time'], stoptime='bar')
+                          starttime=self.record_columns['time'], stoptime='bar')
 
     def test_add_rtp_task_resource_record(self):
         self.test_session.add_obs(*self.observation_values)
@@ -322,9 +343,18 @@ class TestRTP(TestHERAMC):
             stoptime=self.task_resource_columns['start_time'] + TimeDelta(2 * 60, format='sec'))
         self.assertEqual(len(result), 2)
 
+        result_most_recent = self.test_session.get_rtp_task_resource_record()
+        self.assertEqual(len(result_most_recent), 1)
+        self.assertEqual(result[1], result_most_recent[0])
+
         result = self.test_session.get_rtp_task_resource_record(
             obsid=self.task_resource_columns['obsid'])
         self.assertEqual(len(result), 2)
+
+        result_obsid_most_recent = self.test_session.get_rtp_task_resource_record(
+            obsid=self.task_resource_columns['obsid'])
+        self.assertEqual(len(result_obsid_most_recent), 2)
+        self.assertEqual(result, result_obsid_most_recent)
 
         result = self.test_session.get_rtp_task_resource_record(
             starttime=self.task_resource_columns['start_time'] - TimeDelta(2, format='sec'),
@@ -333,6 +363,11 @@ class TestRTP(TestHERAMC):
         self.assertEqual(len(result), 1)
         result = result[0]
         self.assertTrue(result.isclose(expected))
+
+        result_task_most_recent = self.test_session.get_rtp_task_resource_record(
+            task_name=self.task_resource_columns['task_name'])
+        self.assertEqual(len(result_task_most_recent), 1)
+        self.assertTrue(result_task_most_recent[0].isclose(expected))
 
         new_task_time = self.task_resource_columns['start_time'] + TimeDelta(3 * 60, format='sec')
 
@@ -353,6 +388,11 @@ class TestRTP(TestHERAMC):
             task_name=self.task_resource_columns['task_name'],
             stoptime=self.task_resource_columns['start_time'] + TimeDelta(5 * 60, format='sec'))
         self.assertEqual(len(result), 2)
+
+        result_task_most_recent = self.test_session.get_rtp_task_resource_record(
+            task_name=self.task_resource_columns['task_name'])
+        self.assertEqual(len(result_task_most_recent), 1)
+        self.assertTrue(result_task_most_recent[0].isclose(result[1]))
 
         result = self.test_session.get_rtp_task_resource_record(
             starttime=self.task_resource_columns['start_time'] - TimeDelta(2, format='sec'),
@@ -402,12 +442,12 @@ class TestRTP(TestHERAMC):
         self.assertRaises(ValueError, self.test_session.add_rtp_task_resource_record, *fake_vals2)
 
         self.test_session.add_rtp_task_resource_record(*self.task_resource_values)
-        self.assertRaises(ValueError, self.test_session.get_rtp_process_record, 1, 2)
 
         self.assertRaises(ValueError, self.test_session.get_rtp_task_resource_record,
-                          task_name=self.task_resource_columns['task_name'])
+                          task_name=self.task_resource_columns['task_name'], most_recent=False)
 
-        self.assertRaises(ValueError, self.test_session.get_rtp_task_resource_record)
+        self.assertRaises(ValueError, self.test_session.get_rtp_task_resource_record,
+                          most_recent=False)
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -96,6 +96,7 @@ class TestRTP(TestHERAMC):
                           *self.status_values[1:])
 
         self.test_session.add_rtp_status(*self.status_values)
+        self.assertRaises(ValueError, self.test_session.get_rtp_status, most_recent=False)
         self.assertRaises(ValueError, self.test_session.get_rtp_status, starttime='unhappy')
         self.assertRaises(ValueError, self.test_session.get_rtp_status,
                           starttime=self.status_columns['time'], stoptime='unhappy')

--- a/hera_mc/tests/test_server_status.py
+++ b/hera_mc/tests/test_server_status.py
@@ -66,7 +66,7 @@ class TestServerStatus(TestHERAMC):
             self.test_session.add_server_status(sub, self.column_values[0],
                                                 *self.column_values[2:11],
                                                 network_bandwidth_mbs=self.column_values[11])
-            result = self.test_session.get_server_status(sub, self.columns['system_time']
+            result = self.test_session.get_server_status(sub, starttime=self.columns['system_time']
                                                          - TimeDelta(2, format='sec'))
             self.assertEqual(len(result), 1)
             result = result[0]
@@ -83,7 +83,7 @@ class TestServerStatus(TestHERAMC):
 
             self.test_session.add_server_status(sub, 'test_host2', *self.column_values[2:11],
                                                 network_bandwidth_mbs=self.column_values[11])
-            result_host = self.test_session.get_server_status(sub, self.columns['system_time']
+            result_host = self.test_session.get_server_status(sub, starttime=self.columns['system_time']
                                                               - TimeDelta(2, format='sec'),
                                                               hostname=self.columns['hostname'],
                                                               stoptime=self.columns['system_time']
@@ -92,14 +92,14 @@ class TestServerStatus(TestHERAMC):
             result_host = result_host[0]
             self.assertTrue(result_host.isclose(expected))
 
-            result_mult = self.test_session.get_server_status(sub, self.columns['system_time']
+            result_mult = self.test_session.get_server_status(sub, starttime=self.columns['system_time']
                                                               - TimeDelta(2, format='sec'),
                                                               stoptime=self.columns['system_time']
                                                               + TimeDelta(2 * 60, format='sec'))
 
             self.assertEqual(len(result_mult), 2)
 
-            result2 = self.test_session.get_server_status(sub, self.columns['system_time']
+            result2 = self.test_session.get_server_status(sub, starttime=self.columns['system_time']
                                                           - TimeDelta(2, format='sec'),
                                                           hostname='test_host2')[0]
             # mc_times will be different, so won't match. set them equal so that we can test the rest
@@ -116,9 +116,11 @@ class TestServerStatus(TestHERAMC):
             self.test_session.add_server_status(sub, self.column_values[0],
                                                 *self.column_values[2:11],
                                                 network_bandwidth_mbs=self.column_values[11])
-            self.assertRaises(ValueError, self.test_session.get_server_status, sub, 'test_host')
             self.assertRaises(ValueError, self.test_session.get_server_status,
-                              sub, self.columns['system_time'], stoptime='test_host')
+                              sub, starttime='test_host')
+            self.assertRaises(ValueError, self.test_session.get_server_status,
+                              sub, starttime=self.columns['system_time'],
+                              stoptime='test_host')
 
             if sub == 'rtp':
                 self.assertRaises(ValueError, RTPServerStatus.create, 'foo',
@@ -132,8 +134,8 @@ class TestServerStatus(TestHERAMC):
         self.assertRaises(ValueError, self.test_session.add_server_status, 'foo',
                           self.column_values[0], *self.column_values[2:11],
                           network_bandwidth_mbs=self.column_values[11])
-        self.assertRaises(ValueError, self.test_session.get_server_status, 'foo',
-                          self.column_values[1])
+        self.assertRaises(ValueError, self.test_session.get_server_status,
+                          'foo', starttime=self.column_values[1])
 
 
 if __name__ == '__main__':

--- a/hera_mc/tests/test_subsystem_error.py
+++ b/hera_mc/tests/test_subsystem_error.py
@@ -84,10 +84,6 @@ class TestSubsystemError(TestHERAMC):
                           'foo', self.subsystem_error_values[2],
                           *self.subsystem_error_values[4:])
 
-        self.assertRaises(ValueError, SubsystemError, 'foo',
-                          self.subsystem_error_values[2],
-                          *self.subsystem_error_values[4:])
-
         self.test_session.add_subsystem_error(self.subsystem_error_values[1],
                                               self.subsystem_error_values[2],
                                               *self.subsystem_error_values[4:])

--- a/hera_mc/tests/test_subsystem_error.py
+++ b/hera_mc/tests/test_subsystem_error.py
@@ -84,6 +84,10 @@ class TestSubsystemError(TestHERAMC):
                           'foo', self.subsystem_error_values[2],
                           *self.subsystem_error_values[4:])
 
+        self.assertRaises(ValueError, SubsystemError, 'foo',
+                          self.subsystem_error_values[2],
+                          *self.subsystem_error_values[4:])
+
         self.test_session.add_subsystem_error(self.subsystem_error_values[1],
                                               self.subsystem_error_values[2],
                                               *self.subsystem_error_values[4:])

--- a/hera_mc/tests/test_subsystem_error.py
+++ b/hera_mc/tests/test_subsystem_error.py
@@ -43,7 +43,7 @@ class TestSubsystemError(TestHERAMC):
                                               self.subsystem_error_values[2],
                                               *self.subsystem_error_values[4:])
 
-        result = self.test_session.get_subsystem_error(self.subsystem_error_columns['time']
+        result = self.test_session.get_subsystem_error(starttime=self.subsystem_error_columns['time']
                                                        - TimeDelta(2 * 60, format='sec'))
         self.assertEqual(len(result), 1)
         result = result[0]
@@ -53,7 +53,7 @@ class TestSubsystemError(TestHERAMC):
         self.test_session.add_subsystem_error(self.subsystem_error_values[1], 'rtp',
                                               *self.subsystem_error_values[4:])
         result_subsystem = \
-            self.test_session.get_subsystem_error(self.subsystem_error_columns['time']
+            self.test_session.get_subsystem_error(starttime=self.subsystem_error_columns['time']
                                                   - TimeDelta(2, format='sec'),
                                                   subsystem=self.subsystem_error_columns['subsystem'],
                                                   stoptime=self.subsystem_error_columns['time']
@@ -62,7 +62,7 @@ class TestSubsystemError(TestHERAMC):
         result_subsystem = result_subsystem[0]
         self.assertTrue(result_subsystem.isclose(expected))
 
-        result_mult = self.test_session.get_subsystem_error(self.subsystem_error_columns['time']
+        result_mult = self.test_session.get_subsystem_error(starttime=self.subsystem_error_columns['time']
                                                             - TimeDelta(2, format='sec'),
                                                             stoptime=self.subsystem_error_columns['time']
                                                             + TimeDelta(2 * 60, format='sec'))
@@ -73,7 +73,7 @@ class TestSubsystemError(TestHERAMC):
         subsystems = [res.subsystem for res in result_mult]
         self.assertEqual(subsystems, ['librarian', 'rtp'])
 
-        result2 = self.test_session.get_subsystem_error(self.subsystem_error_columns['time']
+        result2 = self.test_session.get_subsystem_error(starttime=self.subsystem_error_columns['time']
                                                         - TimeDelta(2, format='sec'),
                                                         subsystem='rtp')[0]
 
@@ -87,6 +87,7 @@ class TestSubsystemError(TestHERAMC):
         self.test_session.add_subsystem_error(self.subsystem_error_values[1],
                                               self.subsystem_error_values[2],
                                               *self.subsystem_error_values[4:])
-        self.assertRaises(ValueError, self.test_session.get_subsystem_error, 'foo')
         self.assertRaises(ValueError, self.test_session.get_subsystem_error,
-                          self.subsystem_error_columns['time'], stoptime='foo')
+                          starttime='foo')
+        self.assertRaises(ValueError, self.test_session.get_subsystem_error,
+                          starttime=self.subsystem_error_columns['time'], stoptime='foo')

--- a/hera_mc/tests/test_weather.py
+++ b/hera_mc/tests/test_weather.py
@@ -93,16 +93,16 @@ class TestWeather(TestHERAMC):
                                         value=wind_directions[0]),
                     weather.WeatherData(time=int(floor(t1.gps)),
                                         variable='temperature', value=temperatures[0])]
-        result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                     variable='wind_speed')
         self.assertEqual(len(result), 1)
         self.assertTrue(result[0].isclose(expected[0]))
 
-        result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                     stoptime=t1)
         self.assertEqual(len(result), 3)
 
-        result = self.test_session.get_weather_data(t1 + TimeDelta(200.0, format='sec'))
+        result = self.test_session.get_weather_data(starttime=t1 + TimeDelta(200.0, format='sec'))
         self.assertEqual(result, [])
 
         expected2 = expected +\
@@ -112,11 +112,18 @@ class TestWeather(TestHERAMC):
                                  variable='wind_direction', value=wind_directions[1]),
              weather.WeatherData(time=int(floor(t2.gps)),
                                  variable='temperature', value=temperatures[1])]
-        result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                     stoptime=t2 + TimeDelta(1.0, format='sec'))
         self.assertEqual(len(result), len(expected2))
 
-        result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+        result = self.test_session.get_weather_data(starttime=t1 + TimeDelta(3.0, format='sec'),
+                                                    stoptime=t2 + TimeDelta(1.0, format='sec'))
+        self.assertEqual(len(result), 3)
+
+        result_most_recent = self.test_session.get_weather_data()
+        self.assertEqual(result, result_most_recent)
+
+        result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                     stoptime=t2 + TimeDelta(1.0, format='sec'),
                                                     variable='temperature')
         expected3 = [expected2[2], expected2[5]]
@@ -137,22 +144,22 @@ class TestWeather(TestHERAMC):
 
         if is_onsite():
             self.test_session.add_weather_data_from_sensors(t1, t2)
-            result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+            result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                         stoptime=t1)
             self.assertTrue(len(result) <= 7)
-            result = self.test_session.get_weather_data(t1 - TimeDelta(3.0, format='sec'),
+            result = self.test_session.get_weather_data(starttime=t1 - TimeDelta(3.0, format='sec'),
                                                         stoptime=t2)
             self.assertTrue(len(result) > 1)
             self.assertTrue(len(result) <= (5 * 4 + 2 * 28))
 
             self.test_session.add_weather_data_from_sensors(t3, t4, variables='wind_speed')
-            result = self.test_session.get_weather_data(t3 - TimeDelta(3.0, format='sec'),
+            result = self.test_session.get_weather_data(starttime=t3 - TimeDelta(3.0, format='sec'),
                                                         stoptime=t4)
             self.assertTrue(len(result) <= 4)
 
             self.test_session.add_weather_data_from_sensors(t3, t4, variables=['wind_direction',
                                                                                'temperature'])
-            result = self.test_session.get_weather_data(t3 - TimeDelta(3.0, format='sec'),
+            result = self.test_session.get_weather_data(starttime=t3 - TimeDelta(3.0, format='sec'),
                                                         stoptime=t3)
             self.assertTrue(len(result) <= 3)
 

--- a/hera_mc/tests/test_weather.py
+++ b/hera_mc/tests/test_weather.py
@@ -130,6 +130,11 @@ class TestWeather(TestHERAMC):
         for i in range(0, len(result)):
             self.assertTrue(result[i].isclose(expected3[i]))
 
+        result_var_most_recent = self.test_session.get_weather_data(variable='temperature')
+        self.assertEqual(result_var_most_recent[0], result[1])
+
+        self.assertRaises(ValueError, self.test_session.get_weather_data, variable='foo')
+
     def test_add_from_sensor(self):
         t1 = Time('2017-11-10 01:15:23', scale='utc')
         t2 = t1 + TimeDelta(280.0, format='sec')
@@ -164,6 +169,17 @@ class TestWeather(TestHERAMC):
             self.assertTrue(len(result) <= 3)
 
             self.assertRaises(ValueError, weather.create_from_sensors, t1, t2, variables='foo')
+
+    def test_weather_errors(self):
+        self.assertRaises(ValueError, weather.WeatherData, time='foo', variable='wind_speed',
+                          value=2.548)
+
+        t1 = Time('2017-11-10 01:15:23', scale='utc')
+        self.assertRaises(ValueError, weather.WeatherData, time=t1, variable='foo',
+                          value=2.548)
+
+        self.assertRaises(ValueError, weather.WeatherData, time=t1, variable='wind_speed',
+                          value='foo')
 
     def test_dump_weather_table(self):
         # Just make sure it doesn't crash.

--- a/hera_mc/tests/test_weather.py
+++ b/hera_mc/tests/test_weather.py
@@ -171,15 +171,15 @@ class TestWeather(TestHERAMC):
             self.assertRaises(ValueError, weather.create_from_sensors, t1, t2, variables='foo')
 
     def test_weather_errors(self):
-        self.assertRaises(ValueError, weather.WeatherData, time='foo', variable='wind_speed',
-                          value=2.548)
+        self.assertRaises(ValueError, self.test_session.add_weather_data, 'foo',
+                          'wind_speed', 2.548)
 
         t1 = Time('2017-11-10 01:15:23', scale='utc')
-        self.assertRaises(ValueError, weather.WeatherData, time=t1, variable='foo',
-                          value=2.548)
+        self.assertRaises(ValueError, self.test_session.add_weather_data, t1,
+                          'foo', 2.548)
 
-        self.assertRaises(ValueError, weather.WeatherData, time=t1, variable='wind_speed',
-                          value='foo')
+        self.assertRaises(ValueError, self.test_session.add_weather_data, t1,
+                          'wind_speed', 'foo')
 
     def test_dump_weather_table(self):
         # Just make sure it doesn't crash.


### PR DESCRIPTION
Add an option to `ms_session._time_filter` to get the most recent entry. Propagate that option to get methods on mc_session that use it and add tests.

I realized the need for this while writing the correlator control code, but did it in another branch to keep the PRs organized.