### PR TITLE
Update script for adding observations to librarian

### DIFF
--- a/scripts/mc_add_observation.py
+++ b/scripts/mc_add_observation.py
@@ -6,9 +6,11 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
+import numpy as np
 from astropy.time import Time, TimeDelta
 
 import aipy
+from pyuvdata import UVData
 
 from hera_mc.observations import Observation
 from hera_mc import mc
@@ -22,21 +24,31 @@ db = mc.connect_to_mc_db(args)
 
 
 for uvfile in args.files:
-    # we need aipy to read the stopt and duration because everything is awful
-    # but first tell AIPY we're allowed to read these variables
-    aipy.miriad.itemtable['stopt'] = 'd'
-    aipy.miriad.itemtable['duration'] = 'd'
-    UV = aipy.miriad.UV(uvfile)
-    obsid = UV['obsid']
+    if os.path.isdir(uvfile):
+        # assume it's a miriad file
+        # we need aipy to read the stopt and duration because everything is awful
+        # but first tell AIPY we're allowed to read these variables
+        aipy.miriad.itemtable['stopt'] = 'd'
+        aipy.miriad.itemtable['duration'] = 'd'
+        UV = aipy.miriad.UV(uvfile)
+        obsid = UV['obsid']
+        stoptime = Time(UV['stopt'], scale='utc', format='gps')
+        starttime = Time(UV['startt'], scale='utc', format='gps')
+    else:
+        # assume it's uvh5
+        uv = UVData()
+        uv.read_uvh5(uvfile, read_data=False)
+        times = np.unique(uv.time_array)
+        starttime = Time(times[0], scale='utc', format='jd')
+        stoptime = Time(times[-1], scale='utc', format='jd')
+        obsid = int(np.floor(starttime.gps))
 
     with db.sessionmaker() as session:
         obs = session.get_obs(obsid)
         if len(obs) > 0:
             print("observation {obs} already in M&C, skipping".format(obs=obsid))
             continue
-        stoptime = Time(UV['stopt'], scale='utc', format='gps')
-        starttime = Time(UV['startt'], scale='utc', format='gps')
-        print("Inserting obsid into M&C:" + str(UV['obsid']))
+        print("Inserting obsid into M&C:" + str(obsid))
 
         session.add_obs(starttime, stoptime, obsid)
     session.commit()

--- a/scripts/mc_add_observation.py
+++ b/scripts/mc_add_observation.py
@@ -6,6 +6,7 @@
 from __future__ import absolute_import, division, print_function
 
 import argparse
+import os
 import numpy as np
 from astropy.time import Time, TimeDelta
 


### PR DESCRIPTION
Before the librarian will accept observations, they must be known to the M&C system. This PR updates the `mc_add_observation.py` script to be compatible with uvh5 files.