### PR TITLE
updated the overlap checker

### DIFF
--- a/hera_mc/cm_health.py
+++ b/hera_mc/cm_health.py
@@ -14,26 +14,16 @@ from . import part_connect as PC
 from . import cm_revisions
 
 
-def check_for_overlap(intervals):
+def check_for_overlap(interval):
     """
     intervals:  gps_time intervals to test for overlap
                 format [[span_1_low, span_1_high], [span_2_low, span_2_high]]
                 if the high values are None, they get set to the max value + 100 sec
     """
-    noends = []
-    xxx = [x for x in intervals[0] + intervals[1] if x is not None]
-    for i, ival in enumerate(intervals):
-        if ival[1] is None:
-            noends.append(i)
-    for i in noends:
-        intervals[i][1] = max(xxx) + 100
-
-    if intervals[1][0] <= intervals[0][0]:
-        if intervals[1][1] > intervals[0][0]:
-            return True
-    elif intervals[1][0] <= intervals[0][1]:
-        return True
-    return False
+    maxx = max([x for x in interval[0] + interval[1] if x is not None]) + 100
+    for i, ival in enumerate(interval):
+        interval[i] = [x if x is not None else maxx for x in ival]
+    return interval[0][1] > interval[1][0] and interval[1][1] > interval[0][0]
 
 
 class Connections:

--- a/hera_mc/tests/test_connections.py
+++ b/hera_mc/tests/test_connections.py
@@ -122,6 +122,10 @@ class TestConnections(TestHERAMC):
         self.assertTrue(x)
         x = cm_health.check_for_overlap([[3, 8], [1, 5]])
         self.assertTrue(x)
+        x = cm_health.check_for_overlap([[1, 8], [8, 10]])
+        self.assertFalse(x)
+        x = cm_health.check_for_overlap([[8, 10], [1, 8]])
+        self.assertFalse(x)
 
     def test_duplicate_connections(self):
         connection = part_connect.Connections()


### PR DESCRIPTION
When I updated the hookup and pulled it back down, the overlap checker found overlaps that just shared an end point (we don't want it to find contiguous but non-overlapping ones).  It did not flag those earlier, which I find very confusing since it did not relate to any new connection.  I've rewritten the overlap checker to fix that (and made it more "elegant").