### PR TITLE
Add antenna status table

### DIFF
--- a/alembic/versions/d208118c58d0_add_ant_status_table.py
+++ b/alembic/versions/d208118c58d0_add_ant_status_table.py
@@ -1,0 +1,37 @@
+"""add ant_status table
+
+Revision ID: d208118c58d0
+Revises: fb372bb87c37
+Create Date: 2019-03-23 00:10:30.704936+00:00
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'd208118c58d0'
+down_revision = 'fb372bb87c37'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('antenna_status',
+                    sa.Column('time', sa.BigInteger(), nullable=False),
+                    sa.Column('antenna_number', sa.Integer(), nullable=False),
+                    sa.Column('antenna_feed_pol', sa.String(), nullable=False),
+                    sa.Column('snap_hostname', sa.String(), nullable=True),
+                    sa.Column('snap_channel_number', sa.Integer(), nullable=True),
+                    sa.Column('adc_mean', sa.Float(), nullable=True),
+                    sa.Column('adc_rms', sa.Float(), nullable=True),
+                    sa.Column('adc_power', sa.Float(), nullable=True),
+                    sa.Column('pam_atten', sa.Integer(), nullable=True),
+                    sa.Column('pam_power', sa.Float(), nullable=True),
+                    sa.Column('eq_coeffs', sa.String(), nullable=True),
+                    sa.PrimaryKeyConstraint('time', 'antenna_number', 'antenna_feed_pol')
+                    )
+
+
+def downgrade():
+    op.drop_table('antenna_status')

--- a/hera_mc/correlator.py
+++ b/hera_mc/correlator.py
@@ -507,11 +507,14 @@ class AntennaStatus(MCDeclarativeBase):
         snap_channel_number: integer
             The SNAP ADC channel number (0-7) to which this antenna is connected
         adc_mean: float
-            Mean ADC value, in ADC units
+            Mean ADC value, in ADC units, meaning raw ADC values interpreted as
+            signed integers between -128 and +127.
         adc_rms: float
-            RMS ADC value, in ADC units
+            RMS ADC value, in ADC units, meaning raw ADC values interpreted as
+            signed integers between -128 and +127.
         adc_power: float
-            Mean ADC power, in ADC units squared
+            Mean ADC power, in ADC units squared, meaning raw ADC values
+            interpreted as signed integers between -128 and +127 and then squared.
         pam_atten: integer
             PAM attenuation setting for this antenna, in dB
         pam_power: astropy time object

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -2739,11 +2739,14 @@ class MCSession(Session):
         snap_channel_number: integer
             The SNAP ADC channel number (0-7) to which this antenna is connected
         adc_mean: float
-            Mean ADC value, in ADC units
+            Mean ADC value, in ADC units, meaning raw ADC values interpreted as
+            signed integers between -128 and +127.
         adc_rms: float
-            RMS ADC value, in ADC units
+            RMS ADC value, in ADC units, meaning raw ADC values interpreted as
+            signed integers between -128 and +127.
         adc_power: float
-            Mean ADC power, in ADC units squared
+            Mean ADC power, in ADC units squared, meaning raw ADC values
+            interpreted as signed integers between -128 and +127 and then squared.
         pam_atten: integer
             PAM attenuation setting for this antenna, in dB
         pam_power: astropy time object

--- a/scripts/mc_monitor_correlator.py
+++ b/scripts/mc_monitor_correlator.py
@@ -81,6 +81,25 @@ with db.sessionmaker() as session:
                 traceback.print_exc(file=sys.stderr)
                 continue
 
+            try:
+                session.add_antenna_status_from_corrcm()
+            except Exception as e:
+                print('%s -- error adding antenna status' % time.asctime(), file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+                continue
+
+            try:
+                session.commit()
+            except sqlalchemy.exc.SQLAlchemyError as e:
+                print('%s -- SQL error committing new antenna status' % time.asctime(), file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+                session.rollback()
+                continue
+            except Exception as e:
+                print('%s -- error committing new antenna status' % time.asctime(), file=sys.stderr)
+                traceback.print_exc(file=sys.stderr)
+                continue
+
     except KeyboardInterrupt:
         print("exiting on SIGINT")
         sys.exit()

--- a/scripts/mc_monitor_correlator.py
+++ b/scripts/mc_monitor_correlator.py
@@ -84,19 +84,19 @@ with db.sessionmaker() as session:
             try:
                 session.add_antenna_status_from_corrcm()
             except Exception as e:
-                print('%s -- error adding antenna status' % time.asctime(), file=sys.stderr)
+                print('{t} -- error adding antenna status'.format(t=time.asctime()), file=sys.stderr)
                 traceback.print_exc(file=sys.stderr)
                 continue
 
             try:
                 session.commit()
             except sqlalchemy.exc.SQLAlchemyError as e:
-                print('%s -- SQL error committing new antenna status' % time.asctime(), file=sys.stderr)
+                print('{t} -- SQL error committing new antenna status'.format(t=time.asctime()), file=sys.stderr)
                 traceback.print_exc(file=sys.stderr)
                 session.rollback()
                 continue
             except Exception as e:
-                print('%s -- error committing new antenna status' % time.asctime(), file=sys.stderr)
+                print('{t} -- error committing new antenna status'.format(t=time.asctime()), file=sys.stderr)
                 traceback.print_exc(file=sys.stderr)
                 continue
 


### PR DESCRIPTION
To track the antenna status as reported in the correlator redis database (from the SNAPs).
