### PR TITLE
Add a test mode for subsystem_error creation

### DIFF
--- a/hera_mc/__init__.py
+++ b/hera_mc/__init__.py
@@ -54,8 +54,12 @@ class MCDeclarativeBase(object):
                 if not np.all(self_c == other_c):
                     print('column {col} is an int-like array, values are not equal'.format(col=c))
                     return False
-            elif self_c is None and other_c is None:
-                pass  # nullable columns, both null
+            elif self_c is None:
+                if other_c is None:
+                    pass  # nullable columns, both null
+                else:
+                    print('column {col} is None in first object and {val} in the second.'.format(col=c, val=other_c))
+                    return False
             else:
                 if hasattr(self, 'tols') and c.name in self.tols.keys():
                     atol = self.tols[c.name]['atol']

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -515,26 +515,33 @@ class MCSession(Session):
                                       starttime=None, stoptime=None, hostname=None,
                                       write_to_file=False, filename=None)
 
-    def add_subsystem_error(self, time, subsystem, severity, log):
+    def add_subsystem_error(self, time, subsystem, severity, log, testing=False):
         """
         Add a new subsystem subsystem_error to the M&C database.
 
         Parameters:
         ------------
-        time: astropy time object
+        time : astropy time object
             time of this error report
-        subsystem: string
+        subsystem : str
             name of subsystem with error
-        severity: integer
+        severity : int
             integer indicating severity level, 1 is most severe
-        log: string
+        log : str
             error message or log file name (TBD)
+        testing : bool
+            Option to just return the objects rather than adding them to the DB.
         """
         from .subsystem_error import SubsystemError
 
         db_time = self.get_current_db_time()
 
-        self.add(SubsystemError.create(db_time, time, subsystem, severity, log))
+        error_obj = SubsystemError.create(db_time, time, subsystem, severity, log)
+
+        if testing:
+            return error_obj
+
+        self.add(error_obj)
 
     def get_subsystem_error(self, most_recent=None, starttime=None,
                             stoptime=None, subsystem=None,

--- a/hera_mc/tests/test_subsystem_error.py
+++ b/hera_mc/tests/test_subsystem_error.py
@@ -39,10 +39,20 @@ class TestSubsystemError(TestHERAMC):
         exp_columns['mc_time'] = int(floor(exp_columns['mc_time'].gps))
         expected = SubsystemError(**exp_columns)
 
+        # try testing mode
+        error_obj = self.test_session.add_subsystem_error(
+            self.subsystem_error_values[1], self.subsystem_error_values[2],
+            *self.subsystem_error_values[4:], testing=True)
+
+        # error_obj.id isn't set because that's autoincremented by the database
+        error_obj.id = expected.id
+
+        self.assertTrue(error_obj.isclose(expected))
+
         self.test_session.add_subsystem_error(self.subsystem_error_values[1],
                                               self.subsystem_error_values[2],
                                               *self.subsystem_error_values[4:])
-
+        # now actually add it
         result = self.test_session.get_subsystem_error(starttime=self.subsystem_error_columns['time']
                                                        - TimeDelta(2 * 60, format='sec'))
         self.assertEqual(len(result), 1)


### PR DESCRIPTION
Add a `testing` boolean keyword. If set to True, the object will be returned rather than added to the database.