### PR TITLE
update to use chart_studio for plotly ploting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ install:
   - conda info -a
   - conda install six numpy astropy scipy python-dateutil sqlalchemy psycopg2
     pandas matplotlib tabulate psutil cartopy pytest-cov pip pycodestyle
-    alembic coveralls pyuvdata h5py
+    alembic coveralls pyuvdata h5py plotly
+  - conda install chart-studio -c plotly
   - conda list
   - pip install git+https://github.com/HERA-Team/hera_qm.git;
   - python setup.py install

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -75,7 +75,8 @@ class Autocorrelations(MCDeclarativeBase):
 
 
 def plot_HERA_autocorrelations_for_plotly(session):
-    from plotly import graph_objs as go, plotly as py
+    from plotly import graph_objects as go
+    from chart_studio import plotly as py
 
     hera_ants = [9, 10, 20, 22, 31, 43, 53, 64, 65, 72, 80, 81, 88, 89, 96, 97, 104, 105, 112]
     # Fill in arrays from the DB.

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -10,8 +10,7 @@ These are key data for tracking antenna performance and failures.
 
 from __future__ import absolute_import, division, print_function
 
-from argparse import Namespace
-import datetime
+import cm_sysutils
 import numpy as np
 from sqlalchemy import (BigInteger, Column, DateTime, Float, Integer,
                         SmallInteger, String)
@@ -78,11 +77,18 @@ def plot_HERA_autocorrelations_for_plotly(session):
     from plotly import graph_objects as go
     from chart_studio import plotly as py
 
-    hera_ants = [9, 10, 20, 22, 31, 43, 53, 64, 65, 72, 80, 81, 88, 89, 96, 97, 104, 105, 112]
-    # Fill in arrays from the DB.
+    hsession = cm_sysutils.Handling(session)
+    stations = hsession.get_all_fully_connected_at_date(at_date='now')
+
+    hera_ants = []
+    for station in stations:
+        if station.antenna_number not in hera_ants:
+            ants = np.append(hera_ants, station.antenna_number)
+    hera_ants = np.unique(ants)
 
     data = []
 
+    # Plot antennas labeled as fully hooked up
     q = (session.query(Autocorrelations).
          filter(Autocorrelations.measurement_type == 0).
          filter(Autocorrelations.antnum.in_(hera_ants)).

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -73,7 +73,7 @@ class Autocorrelations(MCDeclarativeBase):
                'value={self.value}>').format(self=self)
 
 
-def plot_HERA_autocorrelations_for_plotly(session):
+def plot_HERA_autocorrelations_for_plotly(session, offline_testing=False):
     if six.PY3:
         from plotly import graph_objects as go
     else:
@@ -87,8 +87,8 @@ def plot_HERA_autocorrelations_for_plotly(session):
     hera_ants = []
     for station in stations:
         if station.antenna_number not in hera_ants:
-            ants = np.append(hera_ants, station.antenna_number)
-    hera_ants = np.unique(ants)
+            hera_ants = np.append(hera_ants, station.antenna_number)
+    hera_ants = np.unique(hera_ants).astype(int)
 
     data = []
 
@@ -126,6 +126,9 @@ def plot_HERA_autocorrelations_for_plotly(session):
     fig = go.Figure(data=scatters,
                     layout=layout,
                     )
-    py.plot(fig, auto_open=False,
-            filename='HERA_daily_autos',
-            )
+    if offline_testing:
+        return fig
+    else:
+        py.plot(fig, auto_open=False,
+                filename='HERA_daily_autos',
+                )

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -10,13 +10,12 @@ These are key data for tracking antenna performance and failures.
 
 from __future__ import absolute_import, division, print_function
 
-import cm_sysutils
 import numpy as np
 import six
 from sqlalchemy import (BigInteger, Column, DateTime, Float, Integer,
                         SmallInteger, String)
 
-from . import MCDeclarativeBase, NotNull
+from . import MCDeclarativeBase, NotNull, cm_sysutils
 
 
 class _MeasurementTypes(object):

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function
 
 import cm_sysutils
 import numpy as np
+import six
 from sqlalchemy import (BigInteger, Column, DateTime, Float, Integer,
                         SmallInteger, String)
 
@@ -74,7 +75,11 @@ class Autocorrelations(MCDeclarativeBase):
 
 
 def plot_HERA_autocorrelations_for_plotly(session):
-    from plotly import graph_objects as go
+    if six.PY3:
+        from plotly import graph_objects as go
+    else:
+        from plotly import graph_objs as go
+
     from chart_studio import plotly as py
 
     hsession = cm_sysutils.Handling(session)

--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -88,7 +88,7 @@ def plot_HERA_autocorrelations_for_plotly(session, offline_testing=False):
     for station in stations:
         if station.antenna_number not in hera_ants:
             hera_ants = np.append(hera_ants, station.antenna_number)
-    hera_ants = np.unique(hera_ants).astype(int)
+    hera_ants = np.unique(hera_ants).astype(int).tolist()
 
     data = []
 

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -107,7 +107,8 @@ class ServerStatus(MCDeclarativeBase):
 
 def plot_host_status_for_plotly(session):
     from astropy.time import Time
-    from plotly import graph_objs as go, plotly
+    from plotly import graph_objects as go
+    from chart_studio import plotly as chart_plotly
 
     THIRTY_DAYS = 24 * 3600 * 30
     gps_time_cutoff = Time.now().gps - THIRTY_DAYS
@@ -170,7 +171,7 @@ def plot_host_status_for_plotly(session):
         layout=layout,
     )
 
-    plotly.plot(
+    chart_plotly.plot(
         fig,
         auto_open=False,
         filename='karoo_host_load_averages',

--- a/hera_mc/server_status.py
+++ b/hera_mc/server_status.py
@@ -10,6 +10,7 @@ the documentation needs to be kept up to date with any changes.
 """
 from __future__ import absolute_import, division, print_function
 
+import six
 from math import floor
 from astropy.time import Time
 from sqlalchemy import Column, Integer, String, Float, BigInteger
@@ -107,7 +108,11 @@ class ServerStatus(MCDeclarativeBase):
 
 def plot_host_status_for_plotly(session):
     from astropy.time import Time
-    from plotly import graph_objects as go
+    if six.PY3:
+        from plotly import graph_objects as go
+    else:
+        from plotly import graph_objs as go
+
     from chart_studio import plotly as chart_plotly
 
     THIRTY_DAYS = 24 * 3600 * 30

--- a/hera_mc/tests/test_autocorrelations.py
+++ b/hera_mc/tests/test_autocorrelations.py
@@ -52,18 +52,9 @@ def test_figure_is_created(test_figure):
 def test_ants_in_figure(mcsession, test_figure, sys_handle):
     # This test is a little tautological however it does check that all
     # antennas we "think" are connected have autocorrelations.
+    # the test session has no entries in this table so it should be null
     figure = test_figure
-
-    stations = sys_handle.get_all_fully_connected_at_date(
-        at_date='now', hookup_type='parts_hera'
-    )
-
-    hera_ants = []
-    for station in stations:
-        if station.antenna_number not in hera_ants:
-            ants = np.append(hera_ants, station.antenna_number)
-    hera_ants = np.unique(ants)
 
     ants_in_fig = [d.name for d in figure.data]
 
-    assert all([ha in ants_in_fig for ha in hera_ants])
+    assert ants_in_fig == []

--- a/hera_mc/tests/test_autocorrelations.py
+++ b/hera_mc/tests/test_autocorrelations.py
@@ -29,7 +29,7 @@ else:
     from plotly import graph_objs as go
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def test_figure(mcsession):
     test_session = mcsession
     figure = autocorrelations.plot_HERA_autocorrelations_for_plotly(

--- a/hera_mc/tests/test_autocorrelations.py
+++ b/hera_mc/tests/test_autocorrelations.py
@@ -1,0 +1,69 @@
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2019 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""Testing for `hera_mc.autocorrelations`."""
+from __future__ import absolute_import, division, print_function
+
+import os
+import copy
+import time
+import datetime
+import hashlib
+from math import floor
+
+import pytest
+import yaml
+import numpy as np
+from astropy.time import Time, TimeDelta
+
+from hera_mc import mc, autocorrelations, cm_sysutils
+import hera_mc.correlator as corr
+from hera_mc.data import DATA_PATH
+from ..tests import onsite, checkWarnings
+
+import six
+if six.PY3:
+    from plotly import graph_objects as go
+else:
+    from plotly import graph_objs as go
+
+
+@pytest.fixture(scope='module')
+def test_figure(mcsession):
+    test_session = mcsession
+    figure = autocorrelations.plot_HERA_autocorrelations_for_plotly(
+        test_session, offline_testing=True
+    )
+    yield figure
+
+    del figure
+
+
+@pytest.fixture(scope='function')
+def sys_handle(mcsession):
+    return cm_sysutils.Handling(mcsession)
+
+
+def test_figure_is_created(test_figure):
+    assert isinstance(test_figure, go.Figure)
+
+
+def test_ants_in_figure(mcsession, test_figure, sys_handle):
+    # This test is a little tautological however it does check that all
+    # antennas we "think" are connected have autocorrelations.
+    figure = test_figure
+
+    stations = sys_handle.get_all_fully_connected_at_date(
+        at_date='now', hookup_type='parts_hera'
+    )
+
+    hera_ants = []
+    for station in stations:
+        if station.antenna_number not in hera_ants:
+            ants = np.append(hera_ants, station.antenna_number)
+    hera_ants = np.unique(ants)
+
+    ants_in_fig = [d.name for d in figure.data]
+
+    assert all([ha in ants_in_fig for ha in hera_ants])


### PR DESCRIPTION
plotly is moving to use `chart_studio` for the plotly call. We will need to install this package on the executing computer too. 
available on [conda with custom channel](https://anaconda.org/plotly/chart-studio) or pip
see https://plot.ly/python/getting-started-with-chart-studio/