### PR TITLE
Add script for adding RTP process events

### DIFF
--- a/scripts/add_rtp_process_event.py
+++ b/scripts/add_rtp_process_event.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2019 the HERA Collaboration
+# Licensed under the 2-clause BSD License
+
+"""
+Script to add an RTP process event record to M&C.
+"""
+from __future__ import print_function, division, absolute_import
+
+import numpy as np
+import h5py
+from astropy.time import Time
+
+import hera_mc.mc as mc
+
+parser = mc.get_mc_argument_parser()
+parser.add_argument(
+    "filename", metavar="FILE", type=str, help="Name of the file to add an event for."
+)
+parser.add_argument(
+    "event",
+    metavar="EVENT",
+    type=str,
+    help=(
+        "Event to add for the file. Must be one of: "
+        '"queued", "started", "finished", "error"'
+    ),
+)
+
+# parse args
+args = parser.parse_args()
+
+# get the obsid from the file
+with h5py.File(args.filename, "r") as h5f:
+    time_array = h5f["Header/time_array"][()]
+t0 = Time(np.unique(time_array)[0], scale="utc", format="jd")
+obsid = int(np.floor(t0.gps))
+
+# add the process event
+db = mc.connect_to_mc_db(args)
+with db.sessionmaker() as session:
+    session.add_rtp_process_event(time=Time.now(), obsid=obsid, event=args.event)


### PR DESCRIPTION
This PR adds a command-line function for adding RTP process events to M&C. This script will be called by the wrapper scripts in `hera_opm` to mark when files are queued/start processing/finish or error.