### PR TITLE
Make tests robust to IERS unavailability

### DIFF
--- a/hera_mc/tests/conftest.py
+++ b/hera_mc/tests/conftest.py
@@ -5,8 +5,6 @@
 """Testing environment setup and teardown for pytest."""
 from __future__ import absolute_import, division, print_function
 
-import socket
-
 import pytest
 import six.moves.urllib as urllib
 from astropy.utils import iers
@@ -30,7 +28,7 @@ def setup_and_teardown_package():
         iers.IERS_A.open(iers.IERS_A_URL)
         t1 = Time.now()
         t1.ut1
-    except(urllib.error.URLError):
+    except(urllib.error.URLError, IOError):
         iers.conf.auto_max_age = None
 
     test_db = mc.connect_to_mc_testing_db()

--- a/hera_mc/tests/test_librarian.py
+++ b/hera_mc/tests/test_librarian.py
@@ -20,7 +20,9 @@ from .. import utils
 @pytest.fixture(scope='module')
 def status():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(6 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(6 * 60, format='sec')
         status_names = ['time', 'num_files', 'data_volume_gb',
                         'free_space_gb', 'upload_min_elapsed',
                         'num_processes', 'git_version', 'git_hash']
@@ -41,7 +43,9 @@ def status():
 @pytest.fixture(scope='module')
 def raidstatus():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(6 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(6 * 60, format='sec')
         raid_status_names = ['time', 'hostname', 'num_disks', 'info']
         raid_status_values = [time, 'raid_1', 16,
                               'megaraid controller is happy']
@@ -61,7 +65,9 @@ def raidstatus():
 @pytest.fixture(scope='module')
 def raiderror():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(6 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(6 * 60, format='sec')
         raid_error_names = ['id', 'time', 'hostname', 'disk', 'log']
         raid_error_values = [1, time, 'raid_1', 'd4', 'unhappy disk']
         raid_error_columns = dict(zip(raid_error_names, raid_error_values))
@@ -80,7 +86,9 @@ def raiderror():
 @pytest.fixture(scope='module')
 def remote():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(6 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(6 * 60, format='sec')
         remote_status_names = ['time', 'remote_name', 'ping_time',
                                'num_file_uploads', 'bandwidth_mbs']
         remote_status_values = [time, 'nrao', .13, 5, 56.4]
@@ -100,7 +108,9 @@ def remote():
 @pytest.fixture(scope='module')
 def file():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(6 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(6 * 60, format='sec')
         obsid = utils.calculate_obsid(time)
         observation_names = ['starttime', 'stoptime', 'obsid']
         observation_values = [time, time + TimeDelta(10 * 60, format='sec'),

--- a/hera_mc/tests/test_rtp.py
+++ b/hera_mc/tests/test_rtp.py
@@ -21,7 +21,9 @@ from hera_mc.data import DATA_PATH
 @pytest.fixture(scope='module')
 def status():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(30 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(30 * 60, format='sec')
         status_names = ['time', 'status', 'event_min_elapsed',
                         'num_processes', 'restart_hours_elapsed']
         status_values = [time, 'happy', 3.6, 8, 10.2]
@@ -41,7 +43,9 @@ def status():
 @pytest.fixture(scope='module')
 def observation():
     class DataHolder(object):
-        time = Time.now() - TimeDelta(30 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(30 * 60, format="sec")
         obsid = utils.calculate_obsid(time)
         observation_names = ['starttime', 'stoptime', 'obsid']
         observation_values = [time, time + TimeDelta(10 * 60, format='sec'),
@@ -62,7 +66,9 @@ def observation():
 @pytest.fixture(scope='module')
 def event(observation):
     class DataHolder(object):
-        time = Time.now() - TimeDelta(30 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(30 * 60, format='sec')
         event_names = ['time', 'obsid', 'event']
         event_values = [time, observation.obsid, 'queued']
         event_columns = dict(zip(event_names, event_values))
@@ -81,7 +87,9 @@ def event(observation):
 @pytest.fixture(scope='module')
 def record(observation):
     class DataHolder(object):
-        time = Time.now() - TimeDelta(30 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(30 * 60, format='sec')
         record_names = ['time', 'obsid', 'pipeline_list', 'rtp_git_version',
                         'rtp_git_hash', 'hera_qm_git_version',
                         'hera_qm_git_hash',
@@ -106,7 +114,9 @@ def record(observation):
 @pytest.fixture(scope='module')
 def task(observation):
     class DataHolder(object):
-        time = Time.now() - TimeDelta(30 * 60, format='sec')
+        # pick a date far in the past just in case IERS is down
+        t0 = Time(2457000, format="jd")
+        time = t0 - TimeDelta(30 * 60, format='sec')
         task_resource_names = ['obsid', 'task_name', 'start_time', 'stop_time',
                                'max_memory', 'avg_cpu_load']
         task_resource_values = [observation.obsid, 'OMNICAL', time,

--- a/hera_mc/tests/test_utils.py
+++ b/hera_mc/tests/test_utils.py
@@ -10,6 +10,7 @@ import numpy.testing as npt
 
 from astropy.time import Time
 from astropy.units import Quantity
+from astropy.utils import iers
 
 from .. import utils
 
@@ -19,12 +20,11 @@ def test_LSTScheduler_lstbinsize():
     test that two bins have the right time separation
     """
     LSTbin_size = 10
-    starttime1 = Time('2019-9-19T05:05:05.0', format='isot', scale='utc')
+    # pick a date far in the past just in case IERS is down
+    starttime1 = Time('2015-9-19T05:05:05.0', format='isot', scale='utc')
     scheduletime1, hour1 = utils.LSTScheduler(starttime1, LSTbin_size)
-    starttime2 = Time('2019-9-19T05:05:15.0', format='isot', scale='utc')
+    starttime2 = Time('2015-9-19T05:05:15.0', format='isot', scale='utc')
     scheduletime2, hour2 = utils.LSTScheduler(starttime2, LSTbin_size)
-    print((hour2 - hour1).hour * 3600)
-    print(LSTbin_size)
     assert np.isclose((hour2 - hour1).hour * 3600, LSTbin_size)
     # length of sidereal second in SI seconds.
     sidesec = Quantity(1, 'sday').to('day').value
@@ -37,12 +37,17 @@ def test_LSTScheduler_multiday():
     test that two bins are at the same LST on different days
     """
     LSTbin_size = 10
-    starttime1 = Time('2019-9-19T05:04:00.0', format='isot', scale='utc')
+    # pick a date far in the past just in case IERS is down
+    starttime1 = Time('2015-9-19T05:04:00.0', format='isot', scale='utc')
     scheduletime1, hour1 = utils.LSTScheduler(starttime1, LSTbin_size)
     # lst is 4 minutes earlier every day
-    starttime2 = Time('2019-9-20T05:00:0.0', format='isot', scale='utc')
+    starttime2 = Time('2015-9-20T05:00:0.0', format='isot', scale='utc')
     scheduletime2, hour2 = utils.LSTScheduler(starttime2, LSTbin_size)
-    assert np.isclose((hour2.hour - hour1.hour) * 3600, 0)
+    if iers.conf.auto_max_age is None:
+        atol = 10  # arcseconds
+    else:
+        atol = 1e-8  # default value
+    assert np.isclose((hour2.hour - hour1.hour) * 3600, 0, atol=atol)
 
 
 def test_reraise_context():


### PR DESCRIPTION
This PR allows for tests to pass even if the IERS tables cannot be downloaded. In many places, the dummy time chosen for adding things to the database was "now". Unfortunately, it seems as though astropy cannot extrapolate from the historical tables it ships with. Any tests that rely on astropy time objects were modified to be suitably far in the past that IERS would issue a warning instead of raising an error.

Once this is merged in, the branches in #410 and #414 will need rebasing.