### PR TITLE
Add ne pols

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -3428,7 +3428,7 @@ class MCSession(Session):
             Observation identification number.
         ant : int
             Antenna number.
-        pol : str ('x' or 'y')
+        pol : str ('x', 'y', 'n', or 'e')
             Polarization name.
         metric : str
             Metric name, foreign key into `metric_list`.
@@ -3451,7 +3451,7 @@ class MCSession(Session):
         ------------
         ant : int or list of integers
             Antenna number. Defaults to returning all antennas.
-        pol : str ('x' or 'y'), or list
+        pol : str ('x', 'y', 'n', or 'e'), or list
             Polarization. Defaults to returning all pols.
         metric : str or list of strings
             Metric name. Defaults to returning all metrics.

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -29,7 +29,7 @@ class AntMetrics(MCDeclarativeBase):
     obsid:      observation identification number, generally equal to the floor
                 of the start time in gps seconds (long integer)
     ant:        Antenna number (int >= 0)
-    pol:        Polarization ('x' or 'y')
+    pol:        Polarization ('x', 'y', 'n', or 'e')
     metric:     Name of metric (str)
     mc_time:    time metric is reported to M&C in floor(gps seconds) (BigInteger)
     val:        Value of metric (double)
@@ -60,7 +60,7 @@ class AntMetrics(MCDeclarativeBase):
             observation identification number.
         ant: integer
             antenna number
-        pol: string ('x' or 'y')
+        pol: string ('x', 'y', 'n', or 'e')
             polarization
         metric: string
             metric name
@@ -78,10 +78,10 @@ class AntMetrics(MCDeclarativeBase):
         try:
             pol = str(pol)
         except ValueError:
-            raise ValueError('pol must be string "x" or "y".')
+            raise ValueError('pol must be string "x", "y", "n", or "e".')
         pol = pol.lower()
-        if pol not in ('x', 'y'):
-            raise ValueError('pol must be string "x" or "y".')
+        if pol not in ('x', 'y', 'n', 'e'):
+            raise ValueError('pol must be string "x", "y", "n", or "e".')
         if not isinstance(metric, six.string_types):
             raise ValueError('metric must be string.')
         if not isinstance(db_time, Time):

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -79,7 +79,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
 @pytest.mark.parametrize(
     'ant,pol,metric,val,err_msg',
     [('0', 'x', 'test', 4.5, 'antenna must be an integer.'),
-     (0, u'\xff', 'test', 4.5, 'pol must be string"x"'),
+     (0, u'\xff', 'test', 4.5, 'pol must be string "x"'),
      (0, 'Q', 'test', 4.5, 'pol must be string'),
      (0, 'x', 4, 4.5, 'metric must be string.'),
      (0, 'x', 'test', 'value', 'val must be castable as float'),
@@ -104,7 +104,7 @@ def test_add_AntMetrics_errors(mcsession, ant, pol, metric, val, err_msg):
 
     # Test exceptions
     with pytest.raises(ValueError) as cm:
-        test_session.add_ant_metric(obsid, ant, pol, metric, mc_time, val)
+        test_session.add_ant_metric(obsid, ant, pol, metric, val)
     assert str(cm.value).startswith(err_msg)
 
 

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -86,7 +86,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
      ]
 
 )
-def test_add_AntMetrics_errors(mcsession, ant, pol, metric, mc_time, val, err_msg):
+def test_add_AntMetrics_errors(mcsession, ant, pol, metric, val, err_msg):
     test_session = mcsession
     # Initialize
     t1 = Time('2016-01-10 01:15:23', scale='utc')

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -134,7 +134,7 @@ def test_create_AntMetrics_bad_mc_time(mcsession):
     obsid = utils.calculate_obsid(t1)
     with pytest.raises(ValueError) as cm:
         AntMetrics.create(obsid, 0, 'x', 'test', obsid, 4.5)
-    assert str(cm.value).startswith('db_time must be and astropy Time object')
+    assert str(cm.value).startswith('db_time must be an astropy Time object')
 
 
 def test_ArrayMetrics(mcsession):

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -77,7 +77,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
 
 
 @pytest.mark.parametrize(
-    'ant,pol,metric,mc_time,val,err_msg',
+    'ant,pol,metric,val,err_msg',
     [('0', 'x', 'test', 4.5, 'antenna must be an integer.'),
      (0, u'\xff', 'test', 4.5, 'pol must be string"x"'),
      (0, 'Q', 'test', 4.5, 'pol must be string'),


### PR DESCRIPTION
allows AntMetrics pols to be 'n' and 'e' as well as 'x' and 'y' 

also splits up one very long test of errors into individual tests

closes #396 