### PR TITLE
Fix RTPProcessRecord script

### DIFF
--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -34,13 +34,14 @@ if __name__ == "__main__":
 
     uv = pyuvdata.UVData()
     uv.read_uvh5(args.file, read_data=False, run_check_acceptability=False)
-    obsid = Time(np.unique(uv.time_array)[0], scale='utc', format='jd')
+    t0 = Time(np.unique(uv.time_array)[0], scale='utc', format='jd')
+    obsid = int(np.floor(t0.gps))
 
     db = mc.connect_to_mc_db(args)
     with db.sessionmaker() as session:
         session.add_rtp_process_record(
             time=Time.now(),
-            obsid=obsid.gps,
+            obsid=obsid,
             pipeline_list=args.pipeline_list,
             rtp_git_version=hera_opm_version_info['version'],
             rtp_git_hash=hera_opm_version_info['git_hash'],

--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -18,7 +18,7 @@ import pyuvdata
 
 if __name__ == "__main__":
     parser = mc.get_mc_argument_parser()
-    parser.add_argument('file', metavar='file', type=str, nargs='+',
+    parser.add_argument('file', metavar='file', type=str, nargs=1,
                         help='Basename of file procesed by RTP')
     parser.add_argument('--pipeline_list', dest='pipeline_list', type=str,
                         required=True,


### PR DESCRIPTION
casts the obsid in add_rtp_process_record to expected format. int(floor( time in gps seconds))