### PR TITLE
update time_conversion doc

### DIFF
--- a/Docs/time_conversion_function
+++ b/Docs/time_conversion_function
@@ -5,3 +5,9 @@ begin
 return t + 315964782;
 end
 $$ language plpgsql;
+
+create function gps2epoch(t bigint) returns bigint as $$
+begin
+return t + 315964782;
+end
+$$ language plpgsql;


### PR DESCRIPTION
added an overloaded gps2epoch for bigint types. Should really look into making an sqlalchemy version so these could be re-added if we need automatically.