### PR TITLE
Give acclen_spectra Int type

### DIFF
--- a/scripts/correlator_control.py
+++ b/scripts/correlator_control.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                         "ignored otherwise. Accumulation length in spectra, "
                         "must be an integer and a multiple of 2048. "
                         "Defaults to a value that produces ~10s integration time. ",
-                        default=None)
+                        type=int, default=None)
     parser.add_argument('--overwrite_take_data', help="Only used if command is "
                         "'take_data', ignored otherwise. Option to force an "
                         "overwrite of the next take data command if there is "


### PR DESCRIPTION
Currently un-typed in the argument parser, acclen is cast as a string but is later compared against being an int and will always fail this check.