### PR TITLE
be more robust against fem_switch values from the correlator

### DIFF
--- a/hera_mc/correlator.py
+++ b/hera_mc/correlator.py
@@ -10,9 +10,11 @@ Includes many SNAP-related things.
 """
 from __future__ import absolute_import, division, print_function
 
-import six
 from math import floor
+import warnings
+
 import numpy as np
+import six
 from astropy.time import Time
 from sqlalchemy import (Column, BigInteger, Integer, Float, Boolean, String,
                         ForeignKey, ForeignKeyConstraint)
@@ -1124,6 +1126,13 @@ def create_antenna_status(corr_cm=None,
         else:
             fem_id = None
         fem_switch = ant_dict['fem_switch']
+        if (fem_switch is not None
+                and fem_switch not in ['antenna', 'load', 'noise']):
+            warnings.warn('fem_switch value is {}, should be one of: '
+                          '"antenna", "load", "noise" or "None". '
+                          'Setting to None.'.format(fem_switch))
+            fem_switch = None
+
         if antenna_feed_pol == 'n':
             fem_lna_power = ant_dict['fem_n_lna_power']
         elif antenna_feed_pol == 'e':

--- a/hera_mc/tests/test_correlator.py
+++ b/hera_mc/tests/test_correlator.py
@@ -186,6 +186,7 @@ def antstatus():
                  'histogram': [np.arange(-128, 182, dtype=np.int).tolist(),
                                (np.zeros((256)) + 12).tolist()]}}
 
+
 @pytest.fixture(scope='module')
 def antstatus_none():
     return {
@@ -1872,6 +1873,7 @@ def test_add_antenna_status_from_corrcm_with_nones(mcsession, antstatus_none):
     result = test_session.get_antenna_status(antenna_number=31)
     result = result[0]
     assert result.isclose(expected)
+
 
 def test_antenna_status_errors(mcsession):
     test_session = mcsession

--- a/hera_mc/tests/test_correlator.py
+++ b/hera_mc/tests/test_correlator.py
@@ -186,7 +186,6 @@ def antstatus():
                  'histogram': [np.arange(-128, 182, dtype=np.int).tolist(),
                                (np.zeros((256)) + 12).tolist()]}}
 
-
 @pytest.fixture(scope='module')
 def antstatus_none():
     return {
@@ -212,7 +211,30 @@ def antstatus_none():
                 'fem_imu_phi': 'None',
                 'fem_temp': 'None',
                 'eq_coeffs': 'None',
-                'histogram': 'None'}}
+                'histogram': 'None'},
+        '31:n': {'timestamp':
+                 datetime.datetime(2016, 1, 5, 20, 44, 52, 739322),
+                 'f_host': 'None',
+                 'host_ant_id': 'None',
+                 'adc_mean': 'None',
+                 'adc_rms': 'None',
+                 'adc_power': 'None',
+                 'pam_atten': 'None',
+                 'pam_power': 'None',
+                 'pam_voltage': 'None',
+                 'pam_current': 'None',
+                 'pam_id': 'None',
+                 'fem_voltage': float('nan'),
+                 'fem_current': float('nan'),
+                 'fem_id': 'None',
+                 'fem_switch': 'Unknown mode',
+                 'fem_e_lna_power': 'None',
+                 'fem_n_lna_power': 'None',
+                 'fem_imu_theta': 'None',
+                 'fem_imu_phi': 'None',
+                 'fem_temp': 'None',
+                 'eq_coeffs': 'None',
+                 'histogram': 'None'}}
 
 
 def test_py3_hashing(config):
@@ -1805,13 +1827,15 @@ def test_add_antenna_status_from_corrcm(mcsession, antstatus):
 
 def test_add_antenna_status_from_corrcm_with_nones(mcsession, antstatus_none):
     test_session = mcsession
-    test_session.add_antenna_status_from_corrcm(
-        ant_status_dict=antstatus_none)
+    checkWarnings(test_session.add_antenna_status_from_corrcm,
+                  func_kwargs={'ant_status_dict': antstatus_none},
+                  message='fem_switch value is Unknown mode')
 
     t1 = Time(datetime.datetime(2016, 1, 5, 20, 44, 52, 741137),
               format='datetime')
     result = test_session.get_antenna_status(
         starttime=t1 - TimeDelta(3.0, format='sec'))
+    assert len(result) == 2
 
     expected = corr.AntennaStatus(time=int(floor(t1.gps)), antenna_number=4,
                                   antenna_feed_pol='e',
@@ -1827,10 +1851,27 @@ def test_add_antenna_status_from_corrcm_with_nones(mcsession, antstatus_none):
                                   fem_temp=None, eq_coeffs=None,
                                   histogram_bin_centers=None, histogram=None)
 
-    assert len(result) == 1
+    result = test_session.get_antenna_status(antenna_number=4)
     result = result[0]
     assert result.isclose(expected)
 
+    expected = corr.AntennaStatus(time=int(floor(t1.gps)), antenna_number=31,
+                                  antenna_feed_pol='n',
+                                  snap_hostname=None, snap_channel_number=None,
+                                  adc_mean=None, adc_rms=None,
+                                  adc_power=None, pam_atten=None,
+                                  pam_power=None, pam_voltage=None,
+                                  pam_current=None, pam_id=None,
+                                  fem_voltage=None, fem_current=None,
+                                  fem_id=None, fem_switch=None,
+                                  fem_lna_power=None, fem_imu_theta=None,
+                                  fem_imu_phi=None,
+                                  fem_temp=None, eq_coeffs=None,
+                                  histogram_bin_centers=None, histogram=None)
+
+    result = test_session.get_antenna_status(antenna_number=31)
+    result = result[0]
+    assert result.isclose(expected)
 
 def test_antenna_status_errors(mcsession):
     test_session = mcsession


### PR DESCRIPTION
The correlator is reporting an 'Unknown mode' for a fem_switch value, which it should not be doing but we should handle that kind of thing without falling over.