### PR TITLE
fixed connection issue and removed user-run check

### DIFF
--- a/hera_mc/cm_active.py
+++ b/hera_mc/cm_active.py
@@ -23,7 +23,6 @@ class ActiveData:
     ----------
     at_date : str, int, float, Time, datetime
     """
-    close_enough = 2.0  # Seconds within which the dates are close enough
 
     def __init__(self, session=None, at_date='now'):
         if session is None:  # pragma: no cover

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -138,6 +138,8 @@ def test_sysdef(sys_handle, mcsession):
                   hookup_type='parts_hera')
     curr = active.set_times(cm_utils.get_astropytime('2017-07-03'))
     assert int(curr) == 1183075218
+    active.load_apriori('now')
+    assert active.apriori['HH700:A'].status == 'not_connected'
 
 
 def test_hookup_cache_file_info(sys_handle, mcsession):

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -136,28 +136,8 @@ def test_sysdef(sys_handle, mcsession):
     part = Namespace(part_type='nope')
     pytest.raises(ValueError, sysdef.setup, part, pol='nope',
                   hookup_type='parts_hera')
-    curr = active.is_data_current('parts', None)
-    assert curr
     curr = active.set_times(cm_utils.get_astropytime('2017-07-03'))
     assert int(curr) == 1183075218
-    active.load_parts()
-    x = active.check()
-    assert len(x) == 0
-    active.parts = 'test'
-    active.load_parts(None)
-    assert active.parts == 'test'
-    active.connections = 'test'
-    active.load_connections(None)
-    assert active.connections == 'test'
-    active.info = 'test'
-    active.load_info(None)
-    assert active.info == 'test'
-    active.apriori = 'test'
-    active.load_apriori(None)
-    assert active.apriori == 'test'
-    active.geo = 'test'
-    active.load_geo(None)
-    assert active.geo == 'test'
 
 
 def test_hookup_cache_file_info(sys_handle, mcsession):

--- a/scripts/hookup.py
+++ b/scripts/hookup.py
@@ -27,7 +27,6 @@ if __name__ == '__main__':
     parser.add_argument('--hide-ports', dest='ports', help="Hide ports on hookup.", action='store_false')
     parser.add_argument('--show-revs', dest='revs', help="Show revs on hookup.", action='store_true')
     parser.add_argument('--file', help="output filename, if desired.  Tags are '.txt', '.html', '.csv' to set type.", default=None)
-    parser.add_argument('--check', dest='check_data', help="Flag to just check active data for given date.", action='store_true')
     # Cache options
     parser.add_argument('--use-cache', dest='use_cache', help="Force cache use (but doesn't rewrite cache)", action='store_true')
     parser.add_argument('--delete-cache-file', dest='delete_cache_file', help="Deletes the local cache file", action='store_true')
@@ -59,10 +58,6 @@ if __name__ == '__main__':
         print(hookup.hookup_cache_file_info())
     elif args.delete_cache_file:
         hookup.delete_cache_file()
-    elif args.check_data:
-        from hera_mc import cm_active
-        active = cm_active.ActiveData(session, at_date=at_date)
-        active.check()
     else:
         hookup_dict = hookup.get_hookup(hpn=args.hpn, pol=args.pol, at_date=at_date,
                                         exact_match=args.exact_match, use_cache=args.use_cache,


### PR DESCRIPTION
This had a subtle and vexing error when reading the active data multiple times.  It also had a time-boundary problem for active parts.  This was found because I have been adding more comprehensive checking.  I've also removed the user-run checks in the interest to make the code more maintainable (there was no remaining reason to keep the check flag within hookup.py).