### PR TITLE
Cminfo redux:  Updates the cminfo and fully connected station to new faster version

### DIFF
--- a/hera_mc/autocorrelations.py
+++ b/hera_mc/autocorrelations.py
@@ -82,7 +82,7 @@ def plot_HERA_autocorrelations_for_plotly(session, offline_testing=False):
     from chart_studio import plotly as py
 
     hsession = cm_sysutils.Handling(session)
-    stations = hsession.get_all_fully_connected_at_date(at_date='now')
+    stations = hsession.get_connected_stations(at_date='now')
 
     hera_ants = []
     for station in stations:

--- a/hera_mc/cm_dossier.py
+++ b/hera_mc/cm_dossier.py
@@ -254,7 +254,7 @@ class PartEntry():
 
 class HookupEntry(object):
     """
-    This is the structure of the hookup entry.  All are keyed on polarization.
+    This is the structure of the hookup entry.  All are keyed on polarization<port.
 
     Parameters
     ----------

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -355,9 +355,10 @@ class Hookup(object):
             return self.cached_hookup_dict
 
         hpn = cm_utils.listify(hpn)
-        if use_cache and self.requested_list_OK_for_cache(hpn):
-            self.read_hookup_cache_from_file()
-            return self._cull_dict(hpn, self.cached_hookup_dict, exact_match)
+        if use_cache:
+            if self.requested_list_OK_for_cache(hpn):
+                self.read_hookup_cache_from_file()
+                return self._cull_dict(hpn, self.cached_hookup_dict, exact_match)
 
         return self.get_hookup_from_db(hpn=hpn, pol=pol, at_date=at_date,
                                        exact_match=exact_match, hookup_type=hookup_type)

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -333,7 +333,8 @@ class Hookup(object):
         exact_match : bool
             Flag for either exact_match or partial
         use_cache : bool
-            Flag to force the cache to be read, if present and keys agree
+            Flag to force the cache to be read, if present and keys agree.  This is largely
+            deprecated, but kept for archival possibilities for the future.
         hookup_type : str or None
             Type of hookup to use (current observing system is 'parts_hera').
             If 'None' it will determine which system it thinks it is based on

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -162,6 +162,8 @@ class Handling:
                 except IndexError:  # pragma: no cover
                     corr[pol] = 'None'
                 station_info.timing[pol] = hud[key].timing[ppkey]
+            if corr['e'] == 'None' and corr['n'] == 'None':
+                continue
             station_info.correlator_input = (str(corr['e']), str(corr['n']))
             station_info.epoch = 'e:{}, n:{}'.format(pe['e'], pe['n'])
             station_conn.append(station_info)
@@ -212,7 +214,7 @@ class Handling:
         stn_arrays = SystemInfo()
         for stn in stations_conn:
             stn_arrays.update_arrays(stn)
-        # latitudes, longitudes output by get_all_fully_connected_at_date are in degrees
+        # latitudes, longitudes output by get_connected_stations are in degrees
         # XYZ_from_LatLonAlt wants radians
         ecef_positions = uvutils.XYZ_from_LatLonAlt(np.array(stn_arrays.lat) * np.pi / 180.,
                                                     np.array(stn_arrays.lon) * np.pi / 180.,

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -118,8 +118,7 @@ class Handling:
             'elevation': station elevation (float)
             'antenna_number': antenna number (integer)
             'correlator_input': correlator input for x (East) pol and y (North) pol (string tuple-pair)
-            'start_date': start of connection in gps seconds (long)
-            'stop_date': end of connection in gps seconds (long or None no end time)
+            'timing': start and stop gps seconds for both pols
 
         Parameters
         -----------
@@ -153,34 +152,21 @@ class Handling:
             current_hookup = hud[key].hookup
             corr = {}
             pe = {}
-            for p, hu in six.iteritems(current_hookup):
-                pol = p[0].lower()
-                pe[pol] = hud[k].hookup_type[p]
+            station_info.timing = {}
+            for ppkey, hu in six.iteritems(current_hookup):
+                pol = ppkey[0].lower()
+                pe[pol] = hud[key].hookup_type[ppkey]
                 cind = self.sysdef.corr_index[pe[pol]] - 1  # The '- 1' makes it the downstream_part
                 try:
                     corr[pol] = "{}>{}".format(hu[cind].downstream_input_port, hu[cind].downstream_part)
                 except IndexError:  # pragma: no cover
                     corr[pol] = 'None'
-            fnd_list = self.geo.get_location([stn], at_date)
-            if len(fnd_list) == 1:
-                fnd = fnd_list[0]
+                station_info.timing[pol] = hud[key].timing[ppkey]
 
-                station_info.correlator_input = (str(corr['e']), str(corr['n']))
-                station_info.epoch = 'e:{}, n:{}'.format(pe['e'], pe['n'])
-                if pe['e'] == pe['n']:
-                    station_info.epoch = str(pe['e'])
-                    station_info.start_date = fctime['start']
-                station_info.stop_date = fctime['end']
-
-
-
-
+            station_info.correlator_input = (str(corr['e']), str(corr['n']))
+            station_info.epoch = 'e:{}, n:{}'.format(pe['e'], pe['n'])
             station_conn.append(station_info)
         return station_conn
-###########################
-
-
-
 
     def get_cminfo_correlator(self, hookup_type=None):
         """

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -24,7 +24,7 @@ def sys_handle(mcsession):
 
 
 def test_ever_fully_connected(sys_handle):
-    now_list = sys_handle.get_all_fully_connected_at_date(
+    now_list = sys_handle.get_connected_stations(
         at_date='now', hookup_type='parts_hera')
     assert len(now_list) == 12
 
@@ -164,11 +164,6 @@ def test_hookup_cache_file_info(sys_handle, mcsession):
     hookup = cm_hookup.Hookup(session=mcsession)
     cfi = hookup.hookup_cache_file_info()
     assert 'json does not exist' in cfi
-
-
-def test_some_fully_connected(sys_handle):
-    x = sys_handle.get_fully_connected_location_at_date('HH701', '2019/02/21')
-    assert x.antenna_number == 701
 
 
 def test_correlator_info(sys_handle):

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -53,6 +53,8 @@ def test_other_hookup(sys_handle, mcsession, capsys):
                            hookup_type='parts_hera')
     assert 'A700:H' in hu.keys()
     hookup.write_hookup_cache_to_file(log_msg='For testing.')
+    hu = hookup.get_hookup('HH', 'all', at_date='now', exact_match=True, use_cache=True)
+    assert len(hu) == 0
     hu = hookup.get_hookup('cache', pol='all', hookup_type='parts_hera')
     out = hookup.show_hookup(hu, state='all', output_format='csv')
     assert '1230375618' in out
@@ -66,6 +68,18 @@ def test_other_hookup(sys_handle, mcsession, capsys):
     hufc = hookup.get_hookup_from_db(['N700'], 'e', at_date='now')
     assert len(hufc.keys()) == 3
     assert hookup.hookup_type, 'parts_hera'
+    gptf = hookup.get_part_types_found([])
+    assert len(gptf) == 0
+
+
+def test_hookup_notes(mcsession, capsys):
+    hookup = cm_hookup.Hookup(session=mcsession)
+    hu = hookup.get_hookup(['HH'])
+    notes = hookup.get_notes(hu)
+    assert len(notes) == 13
+    print(hookup.show_notes(hu))
+    captured = capsys.readouterr()
+    assert '---HH700:A---' in captured.out.strip()
 
 
 def test_hookup_dossier(sys_handle, capsys):


### PR DESCRIPTION
The cm_sysutils methods for get_fully_connected_XXX (and therefore the cminfo method) was very inefficient and unnecessarily looped several times over stations.  Being slow was hampering the correlator.  This fixes that.  Two interfaces changed:

get_all_fully_connected_at_date --> get_connected_stations
the object lost the 'started'/'stopped' attributes for a more general 'timing' attribute

I've changed instances in the repo, but I don't know if any other repo uses these (although I strongly doubt that they do).