### PR TITLE
Update sqlalchemy filter logic

### DIFF
--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -2,12 +2,11 @@ name: tests
 channels:
   - defaults
   - conda-forge
-  - plotly
 dependencies:
   - alembic
   - astropy
   - cartopy
-  - chart-studio
+  - plotly::chart-studio
   - h5py
   - matplotlib
   - numpy
@@ -23,5 +22,7 @@ dependencies:
   - six
   - sqlalchemy
   - tabulate
+  - redis-py
+  - pyyaml
   - pip:
       - git+https://github.com/HERA-Team/hera_qm.git

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -22,7 +22,6 @@ dependencies:
   - six
   - sqlalchemy
   - tabulate
-  - redis-py
   - pyyaml
   - pip:
       - git+https://github.com/HERA-Team/hera_qm.git

--- a/hera_mc/cm_handling.py
+++ b/hera_mc/cm_handling.py
@@ -74,8 +74,9 @@ class Handling:
         at_date = cm_utils.get_astropytime(at_date)
 
         # get last row before at_date
-        result = self.session.query(CMVersion).filter(CMVersion.update_time < at_date.gps).order_by(
-            desc(CMVersion.update_time)).limit(1).all()
+        result = (self.session.query(CMVersion).filter(CMVersion.update_time <= at_date.gps)
+                  .order_by(desc(CMVersion.update_time)).limit(1).all()
+                  )
         return result[0].git_hash
 
     def get_part_type_for(self, hpn):

--- a/hera_mc/geo_handling.py
+++ b/hera_mc/geo_handling.py
@@ -193,7 +193,7 @@ class Handling:
         query_date = cm_utils.get_astropytime(query_date)
         connected_antenna = self.session.query(cm_partconnect.Connections).filter(
             (func.upper(cm_partconnect.Connections.upstream_part) == station.upper())
-            & (query_date.gps >= cm_partconnect.Connections.start_gpstime))
+            & (cm_partconnect.Connections.start_gpstime <= query_date.gps))
         antenna_connected = []
         for conn in connected_antenna:
             if conn.stop_gpstime is None or query_date.gps <= conn.stop_gpstime:
@@ -234,7 +234,7 @@ class Handling:
             antenna = 'A' + antenna
         connected_antenna = self.session.query(cm_partconnect.Connections).filter(
             (func.upper(cm_partconnect.Connections.downstream_part) == antenna.upper())
-            & (query_date.gps >= cm_partconnect.Connections.start_gpstime))
+            & (cm_partconnect.Connections.start_gpstime <= query_date.gps))
         ctr = 0
         for conn in connected_antenna:
             if conn.stop_gpstime is None or query_date.gps <= conn.stop_gpstime:

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -112,16 +112,19 @@ def test_plotting(geo_handle):
     geo_handle.plot_all_stations()
 
 
-def test_antenna_label(geo_handle):
+@pytest.mark.parametrize(
+    ('label_type, val'), [
+        ('name', 'HH700'),
+        ('num', '700'),
+        ('ser', '700')
+    ]
+)
+def test_antenna_label(geo_handle, label_type, val):
     stations_to_plot = ['HH700']
     query_date = Time('2019-09-20 01:00:00', scale='utc')
     stations = geo_handle.get_location(stations_to_plot, query_date)
-    x = geo_handle.get_antenna_label('name', stations[0], query_date)
-    assert x == 'HH700'
-    x = geo_handle.get_antenna_label('num', stations[0], query_date)
-    assert x == '700'
-    x = geo_handle.get_antenna_label('ser', stations[0], query_date)
-    assert x == '700'
+    x = geo_handle.get_antenna_label(label_type, stations[0], query_date)
+    assert x == val
 
 
 def test_geo_handling(geo_handle):


### PR DESCRIPTION
Changes a few filter calls in queries. Two change queries to use the class variable first (complained if the desired value came first in python 3.8 for some reason).
The third uses a `<=` opposed to `<` when comparing times for the version query. This was a necessary addition in python 3.8 to get a result. I'm am not sure _why_ it was like this though.

Changed one test into a parametrize which was failing in python 3.8 to identify exactly what was causing the error.