### PR TITLE
WIP: Use time_filter in metrics methods

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4645,7 +4645,7 @@ class MCSession(Session):
         obj_list = [AntMetrics.create(obsid, ant, pol, metric, db_time, val)]
         self._insert_ignoring_duplicates(AntMetrics, obj_list, update=True)
 
-    def _metric_time_to_time_filter(time, start=True):
+    def _metric_time_to_time_filter(self, time, start=True):
         """
         Aligns time keywords between metric functions and _time_filter.
 

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4670,10 +4670,12 @@ class MCSession(Session):
             starttime = Time(0, format='gps')
         elif not isinstance(starttime, Time):
             starttime = Time(starttime, format='gps')
+
         if stoptime is None:
-            stoptime = Time(0, format='gps')
-        elif not isinstance(starttime, Time):
+            stoptime = Time.now()
+        elif not isinstance(stoptime, Time):
             stoptime = Time(stoptime, format='gps')
+
         return starttime, stoptime
 
     def get_ant_metric(self, ant=None, pol=None, metric=None, starttime=None,

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4674,9 +4674,11 @@ class MCSession(Session):
         list of AntMetrics objects
 
         """
-        if not isinstance(starttime, Time):
+        if not (starttime is None or isinstance(starttime, Time)):
+            # Convert gps to astropy Time object, but leave None alone
             starttime = Time(starttime, format='gps')
-        if not isinstance(stoptime, Time):
+        if not (stoptime is None or isinstance(stoptime, Time)):
+            # Convert gps to astropy Time object, but leave None alone
             stoptime = Time(stoptime, format='gps')
         query = self._time_filter(AntMetrics, 'obsid', starttime=starttime,
                                   stoptime=stoptime, return_query=True)
@@ -4738,9 +4740,11 @@ class MCSession(Session):
         list of ArrayMetrics objects
 
         """
-        if not isinstance(starttime, Time):
+        if not (starttime is None or isinstance(starttime, Time)):
+            # Convert gps to astropy Time object, but leave None alone
             starttime = Time(starttime, format='gps')
-        if not isinstance(stoptime, Time):
+        if not (stoptime is None or isinstance(stoptime, Time)):
+            # Convert gps to astropy Time object, but leave None alone
             stoptime = Time(stoptime, format='gps')
         query = self._time_filter(ArrayMetrics, starttime=starttime,
                                   stoptime=stoptime, return_query=True)

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4690,7 +4690,7 @@ class MCSession(Session):
             args.append(AntMetrics.metric.in_(get_iterable(metric)))
         query = query.filter(*args)
         if write_to_file:
-            self._write_query_to_file(query, ArrayMetrics, filename=filename)
+            self._write_query_to_file(query, AntMetrics, filename=filename)
         else:
             return query.all()
 

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4719,17 +4719,12 @@ class MCSession(Session):
         """
         args = []
         if metric is not None:
-            args.append(ArrayMetrics.metric.in_(get_iterable(metric)))
-        if starttime is None:
-            starttime = 0
-        elif isinstance(starttime, Time):
-            starttime = starttime.gps
-        if stoptime is None:
-            stoptime = Time.now().gps
-        elif isinstance(stoptime, Time):
-            stoptime = stoptime.gps
-        args.append(ArrayMetrics.obsid.between(starttime, stoptime))
-        return self.query(ArrayMetrics).filter(*args).all()
+            filter_column = 'metric'
+        else:
+            filter_column = None
+        return self._time_filter(ArrayMetrics, 'obsid', starttime=starttime,
+                                 stoptime=stoptime, filter_column=filter_column,
+                                 filter_value=metric)
 
     def add_metric_desc(self, metric, desc):
         """

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4717,7 +4717,6 @@ class MCSession(Session):
         list of ArrayMetrics objects
 
         """
-        args = []
         if metric is not None:
             filter_column = 'metric'
         else:

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4746,7 +4746,7 @@ class MCSession(Session):
         if not (stoptime is None or isinstance(stoptime, Time)):
             # Convert gps to astropy Time object, but leave None alone
             stoptime = Time(stoptime, format='gps')
-        query = self._time_filter(ArrayMetrics, starttime=starttime,
+        query = self._time_filter(ArrayMetrics, 'obsid', starttime=starttime,
                                   stoptime=stoptime, return_query=True)
         args = []
         if metric is not None:

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4645,7 +4645,7 @@ class MCSession(Session):
         obj_list = [AntMetrics.create(obsid, ant, pol, metric, db_time, val)]
         self._insert_ignoring_duplicates(AntMetrics, obj_list, update=True)
 
-    def _metric_time_to_time_filter(self, time, start=True):
+    def _metric_time_to_time_filter(self, starttime, stoptime):
         """
         Aligns time keywords between metric functions and _time_filter.
 
@@ -4654,25 +4654,27 @@ class MCSession(Session):
 
         Parameters
         ----------
-        time : astropy Time object OR gps second.
-            Time keyword to be converted from metric input to _time_filter input
-        start : bool, optional
-            If True (default), time is interpreted as a starttime. Otherwise
-            interpreted as a stop time.
+        starttime : astropy Time object OR gps second.
+            starttime keyword to be converted from metric input to _time_filter input
+        stoptime : astropy Time object OR gps second.
+            starttime keyword to be converted from metric input to _time_filter input
 
         Returns
         -------
-        time : astropy Time object
-            The start- or stoptime to be passed to _time_filter.
+        starttime : astropy Time object
+            The starttime to be passed to _time_filter.
+        stoptime : astropy Time object
+            The stoptime to be passed to _time_filter.
         """
-        if time is None:
-            if start:
-                time = Time(0, format='gps')
-            else:
-                time = Time.now()
-        elif not isinstance(time, Time):
-            time = Time(time, format='gps')
-        return time
+        if starttime is None:
+            starttime = Time(0, format='gps')
+        elif not isinstance(starttime, Time):
+            starttime = Time(starttime, format='gps')
+        if stoptime is None:
+            stoptime = Time(0, format='gps')
+        elif not isinstance(starttime, Time):
+            stoptime = Time(stoptime, format='gps')
+        return starttime, stoptime
 
     def get_ant_metric(self, ant=None, pol=None, metric=None, starttime=None,
                        stoptime=None, write_to_file=False, filename=None):
@@ -4703,8 +4705,7 @@ class MCSession(Session):
         list of AntMetrics objects
 
         """
-        starttime = self._metric_time_to_time_filter(starttime, start=True)
-        stoptime = self._metric_time_to_time_filter(stoptime, start=False)
+        starttime, stoptime = self._metric_time_to_time_filter(starttime, stoptime)
         query = self._time_filter(AntMetrics, 'obsid', starttime=starttime,
                                   stoptime=stoptime, return_query=True)
 
@@ -4765,8 +4766,7 @@ class MCSession(Session):
         list of ArrayMetrics objects
 
         """
-        starttime = self._metric_time_to_time_filter(starttime, start=True)
-        stoptime = self._metric_time_to_time_filter(stoptime, start=False)
+        starttime, stoptime = self._metric_time_to_time_filter(starttime, stoptime)
         query = self._time_filter(ArrayMetrics, 'obsid', starttime=starttime,
                                   stoptime=stoptime, return_query=True)
         args = []


### PR DESCRIPTION
As requested, antenna and array metric methods now use time_filter.

To do this, I had to do a couple things:
- `get_ant_metric` uses more complex queries than are possible with `_time_filter`, so I added a keyword to `_time_filter` so it will return the query object, then `get_ant_metric` can add to it before actually calling it.
- The default behavior for ant/array metrics is different than it is for `_time_filter`, so I added an internal function, `_metric_time_to_time_filter` to align the two.

Still needs tests, but hoping @bhazelton could take a look to sign off on the approach.

Closes #397 