### PR TITLE
Fix 3.8 tests

### DIFF
--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -28,7 +28,7 @@ conda list -n ${ENV_NAME}
 # there's an issue on python 3.8 with sip being out of date
 # Try manually updating it.
 if [[ $ENV_NAME == 'tests' ]]; then
-conda install -n ${ENV_NAME} sip">4.19.8"
+conda update pyqt -c conda-forge
 fi
 conda list -n ${ENV_NAME}
 

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -25,7 +25,11 @@ fi
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
 
-conda update sip
+# there's an issue on python 3.8 with sip being out of date
+# Try manually updating it.
+if [[ $ENV_NAME == 'tests' ]]; then
+conda update -n ${ENV_NAME} sip
+fi
 conda list -n ${ENV_NAME}
 
 # check that the python version matches the desired one; exit immediately if not

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -28,7 +28,7 @@ conda list -n ${ENV_NAME}
 # there's an issue on python 3.8 with sip being out of date
 # Try manually updating it.
 if [[ $ENV_NAME == 'tests' ]]; then
-conda update -n ${ENV_NAME} sip
+conda install -n ${ENV_NAME} sip">4.19.8"
 fi
 conda list -n ${ENV_NAME}
 

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -25,12 +25,6 @@ fi
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
 
-# there's an issue on python 3.8 with sip being out of date
-# Try manually updating it.
-if [[ $ENV_NAME == 'tests' ]]; then
-conda update pyqt -c conda-forge
-fi
-conda list -n ${ENV_NAME}
 
 # check that the python version matches the desired one; exit immediately if not
 PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -22,6 +22,8 @@ else
   conda env update -n ${ENV_NAME} -f ci/${ENV_NAME}.yaml
 fi
 
+conda update sip
+
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
 # check that the python version matches the desired one; exit immediately if not

--- a/ci/install_conda.sh
+++ b/ci/install_conda.sh
@@ -22,10 +22,12 @@ else
   conda env update -n ${ENV_NAME} -f ci/${ENV_NAME}.yaml
 fi
 
-conda update sip
-
 source activate ${ENV_NAME}
 conda list -n ${ENV_NAME}
+
+conda update sip
+conda list -n ${ENV_NAME}
+
 # check that the python version matches the desired one; exit immediately if not
 PYVER=`python -c "from __future__ import print_function; import sys; print('{:d}.{:d}'.format(sys.version_info.major, sys.version_info.minor))"`
 if [[ $PYVER != $PYTHON ]]; then

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -24,6 +24,7 @@ dependencies:
   - tabulate
   - pyyaml
   - redis-py
+  - conda-forge::pyqt
   - pip:
       - git+https://github.com/HERA-Team/hera_qm.git
       - git+https://github.com/HERA-Team/hera_corr_cm.git


### PR DESCRIPTION
Grabs `pyqt` from `conda-forge` the mains channel is having a `sip` versioning issue on some machines, most notably the vms that github actions uses.

We should monitor pyqt on the main channel to remove the workaround.