### PR TITLE
Harmonize cminfo

### DIFF
--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -125,7 +125,7 @@ def cminfo_redis_loc(cminfo):
     locations['antenna_positions'] = antenna_positions
     locations['antenna_utm_eastings'] = cminfo['antenna_utm_eastings']
     locations['antenna_utm_northings'] = cminfo['antenna_utm_northings']
-    locations['antenna_alts'] = cminfo['antenna_alt']
+    locations['antenna_alts'] = cminfo['antenna_alts']
     locations['cofa'] = {'lat': cminfo['cofa_lat'], 'lon': cminfo['cofa_lon'],
                          'alt': cminfo['cofa_alt']}
     locations['cofa_xyz'] = {'X': cminfo['cofa_X'], 'Y': cminfo['cofa_Y'],

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -117,6 +117,7 @@ def cminfo_redis_loc(cminfo):
         Dictionary containing the lat, lon, alt of the center-of-array
     """
     locations = {}
+    locations['correlator_inputs'] = cminfo['correlator_inputs']
     locations['antenna_numbers'] = cminfo['antenna_numbers']
     locations['antenna_names'] = cminfo['antenna_names']
     antenna_positions = []

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -232,14 +232,13 @@ class Handling:
                 # This is actually station names, not antenna names,
                 # but antenna_names is what it's called in pyuvdata
                 'antenna_names': stn_arrays.station_name,
-                'station_types': stn_arrays.station_type_name,
                 # this is a tuple giving the f-engine names for x, y
                 'correlator_inputs': stn_arrays.correlator_input,
                 'utm_datum': stn_arrays.datum[0],
                 'utm_tile': stn_arrays.tile[0],
                 'antenna_utm_eastings': stn_arrays.easting,
                 'antenna_utm_northings': stn_arrays.northing,
-                'antenna_alt': stn_arrays.elevation,
+                'antenna_alts': stn_arrays.elevation,
                 'antenna_positions': rotecef_positions,
                 'cm_version': cm_version,
                 'cofa_lat': cofa_loc.lat,

--- a/hera_mc/correlator.py
+++ b/hera_mc/correlator.py
@@ -44,7 +44,8 @@ command_dict = {'take_data': 'take_data',
                 'noise_diode_off': 'noise_diode_disable',
                 'load_on': 'load_enable',
                 "load_off": 'load_disable',
-                'update_config': 'update_config', 'restart': 'restart'}
+                'update_config': 'update_config',
+                'restart': 'restart'}
 
 command_state_map = {'take_data': {'allowed_when_recording': False},
                      'stop_taking_data': {'state_type': 'taking_data',

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -230,13 +230,10 @@ def test_correlator_info(sys_handle):
 
     corr_inputs = corr_dict['correlator_inputs']
 
-    stn_types = corr_dict['station_types']
-
     index = np.where(np.array(ant_names) == 'HH703')[0]
     assert len(index) == 1
     index = index[0]
 
-    assert stn_types[index] == 'herahexw'
     assert corr_inputs[index] == ('e10>SNPA000700', 'n8>SNPA000700')
 
     assert ([int(name.split('HH')[1]) for name in ant_names]
@@ -259,7 +256,7 @@ def test_correlator_info(sys_handle):
     assert corr_dict['cm_version'] == mc_git_hash
 
     expected_keys = ['antenna_numbers', 'antenna_names', 'correlator_inputs',
-                     'utm_datum', 'utm_tile', 'antenna_utm_eastings', 'antenna_alt',
+                     'utm_datum', 'utm_tile', 'antenna_utm_eastings', 'antenna_alts',
                      'antenna_utm_northings', 'antenna_positions',
                      'cm_version', 'cofa_lat', 'cofa_lon', 'cofa_alt',
                      'cofa_X', 'cofa_Y', 'cofa_Z']

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -258,9 +258,8 @@ def test_correlator_info(sys_handle):
 
     assert corr_dict['cm_version'] == mc_git_hash
 
-    expected_keys = ['antenna_numbers', 'antenna_names', 'station_types',
-                     'correlator_inputs', 'utm_datum',
-                     'utm_tile', 'antenna_utm_eastings', 'antenna_alt',
+    expected_keys = ['antenna_numbers', 'antenna_names', 'correlator_inputs',
+                     'utm_datum', 'utm_tile', 'antenna_utm_eastings', 'antenna_alt',
                      'antenna_utm_northings', 'antenna_positions',
                      'cm_version', 'cofa_lat', 'cofa_lon', 'cofa_alt',
                      'cofa_X', 'cofa_Y', 'cofa_Z']


### PR DESCRIPTION
For paper_gpu we need to add correlator_inputs to redis.  I also "harmonized" plural on alts and took out a few cminfo lists that don't get used anywhere.