### PR TITLE
Make changes to script to handle pyuvdata's new versioning scheme

### DIFF
--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -71,7 +71,8 @@ if __name__ == "__main__":
         pyuvdata_git_hash = split_local[0][1:]
 
     uv = pyuvdata.UVData()
-    uv.read_uvh5(args.file, read_data=False, run_check_acceptability=False)
+    # args.file is a length-1 list
+    uv.read_uvh5(args.file[0], read_data=False, run_check_acceptability=False)
     t0 = Time(np.unique(uv.time_array)[0], scale='utc', format='jd')
     obsid = int(np.floor(t0.gps))
 

--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -37,7 +37,7 @@ if __name__ == "__main__":
 
     # special handling for pyuvdata because it uses setuptools_scm
     pyuvdata_version = pyuvdata.__version__
-    parsed_version = (pyuvdata_version)
+    parsed_version = parse_version(pyuvdata_version)
     pyuvdata_tag = parsed_version.base_version
     local = parsed_version.local
 

--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -6,6 +6,9 @@
 """Add individual processing record to M&C database from RTP."""
 from __future__ import absolute_import, division, print_function
 
+import warnings
+from pkg_resources import parse_version
+
 import numpy as np
 from astropy.time import Time
 
@@ -27,10 +30,45 @@ if __name__ == "__main__":
                         )
     args = parser.parse_args()
 
-    pyuvdata_version_info = pyuvdata.version.construct_version_info()
+    # get version info for relevant repos
     hera_qm_version_info = hera_qm.version.construct_version_info()
     hera_cal_version_info = hera_cal.version.construct_version_info()
     hera_opm_version_info = hera_opm.version.construct_version_info()
+
+    # special handling for pyuvdata because it uses setuptools_scm
+    pyuvdata_version = pyuvdata.__version__
+    parsed_version = (pyuvdata_version)
+    pyuvdata_tag = parsed_version.base_version
+    local = parsed_version.local
+
+    if local is None:
+        # we're running from a "clean" (tagged/released) repo
+        # get the git info from GitHub directly
+        from subprocess import CalledProcessError, check_output
+
+        gitcmd = [
+            "git",
+            "ls-remote",
+            "https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git",
+            f"v{pyuvdata_tag}",
+        ]
+
+        try:
+            output = check_output(gitcmd).decode("utf-8")
+            pyuvdata_git_hash = output.split()[0]
+        except CalledProcessError:
+            pyuvdata_git_hash = "???"
+    else:
+        # check if version has a "dirty" tag
+        split_local = local.split(".")
+        if len(split_local) > 1:
+            warnings.warn(
+                "pyuvdata was installed with uncommited changes. Please commit "
+                "changes and reinstall."
+            )
+
+        # get git info from tag -- the hash has a leading "g" that we ignore
+        pyuvdata_git_hash = split_local[0][1:]
 
     uv = pyuvdata.UVData()
     uv.read_uvh5(args.file, read_data=False, run_check_acceptability=False)
@@ -49,7 +87,6 @@ if __name__ == "__main__":
             hera_qm_git_hash=hera_qm_version_info['git_hash'],
             hera_cal_git_version=hera_cal_version_info['version'],
             hera_cal_git_hash=hera_cal_version_info['git_hash'],
-            pyuvdata_git_version=pyuvdata_version_info['version'],
-            pyuvdata_git_hash=pyuvdata_version_info['git_hash']
-
+            pyuvdata_git_version=pyuvdata_tag,
+            pyuvdata_git_hash=pyuvdata_git_hash,
         )


### PR DESCRIPTION
This PR includes changes to handle pyuvdata's new versioning scheme built on `setuptools_scm`. Before we were calling `pyuvdata.version.construct_version_info()`, but this module and function have been removed. The git information is now available in the `__version__` tag of pyuvdata, except in the case that a tagged/released version is installed. In that case, we retrieve the git hash from GitHub directly.

~I'll test this on site and make sure it behaves as expected. I'll push any necessary changes to this branch.~ This has been tested on site and seems to work.