### PR TITLE
Remove hera_corr_cm.ERROR check

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -2935,7 +2935,6 @@ class MCSession(Session):
             # HERACorrCM object instance (which is created in the next line if
             # it doesn't already exist).
             self.add_corr_obj(force=force)
-            import hera_corr_cm
             # There are a couple special cases where we need to pass extra
             # arguments (take_data, update_config). Handle them specifically,
             # otherwise just call the appropriate method in the `else` clause.

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -2952,9 +2952,9 @@ class MCSession(Session):
                 starttime_used_unix_ms = \
                     getattr(self.corr_obj, corr.command_dict[command])(
                         starttime_ms, duration, acclen_spectra, tag=tag)
-                if starttime_used_unix_ms is hera_corr_cm.ERROR:
+                if starttime_used_unix_ms is False:
                     raise RuntimeError(
-                        'take_data correlator command returned an ERROR, on '
+                        'take_data correlator command returned a False state, on '
                         'inputs: {t}, {d}, {acc}, {tag}'.format(
                             t=starttime_ms,
                             d=duration,


### PR DESCRIPTION
removes the check against `hera_corr_cm.ERROR` when trying to calling `take_data` via `correlator_control.py`. Corr_cm now uses just True and False states instead of ERROR/OK