### PR TITLE
change to update rosetta

### DIFF
--- a/hera_mc/cm_partconnect.py
+++ b/hera_mc/cm_partconnect.py
@@ -47,38 +47,60 @@ class PartRosetta(MCDeclarativeBase):
                 '{self.stop_gpstime}>'.format(self=self))
 
 
-def add_part_rosetta(session, hpn, syspn, start_date, stop_date=None):
+def update_part_rosetta(hpn, syspn, at_date, date2=None, session=None):
     """
-    Add part information into database.
+    Update rosetta relationship in part_rosetta table.
+
+    If hpn <-> syspn relationship is active, will close it at at_date.
+    If hpn <-> syspn relationship is NOT active, it will start it at at_date.
+    If date2 is None, at_date is used as either start or stop, as appropriate.
+    Note that hpn is cast to upper, but syspn is not modified.
 
     Parameters
     ----------
-    session : object
-        Database session to use.  If None, it will start a new session, then close.
     hpn : str
         HERA part number
     syspn : str
         System part number
-    start_date : any format that cm_utils.get_astropytime understands
-        Date to use for the start
-    stop_date : any format that cm_utils.get_astropytime understands
-        Date to use for the stop
+    at_date : any format that cm_utils.get_astropytime understands
+        Date to use for action: start for new is relationship not active, else stop.
+    date2 : any format that cm_utils.get_astropytime understands
+        If not None, use for stop
+    session : object
+        Database session to use.  If None, it will start a new session, then close.
     """
+    hpn = hpn.upper()
+    at_date = int(cm_utils.get_astropytime(at_date).gps)
+    if date2 is not None:
+        date2 = int(cm_utils.get_astropytime(date2).gps)
+
     close_session_when_done = False
     if session is None:  # pragma: no cover
         db = mc.connect_to_mc_db(None)
         session = db.sessionmaker()
         close_session_when_done = True
 
-    rose = PartRosetta()
-    rose.hpn = hpn
-    rose.syspn = syspn
-    rose.start_gpstime = int(cm_utils.get_astropytime(start_date).gps)
-    if stop_date is None:
-        rose.stop_gpstime = None
+    old_rose = None
+    ctr = 0
+    for trial in session.query(PartRosetta).filter(
+            (func.upper(PartRosetta.hpn) == hpn) &  # noqa
+            (func.upper(PartRosetta.syspn) == syspn.upper())):
+        if trial.stop_gpstime is None:
+            ctr += 1
+            old_rose = trial
+    if ctr > 1:
+        raise ValueError("Multiple rosetta relationship active for {} - {}".format(hpn, syspn))
+    if old_rose is None:
+        new_rose = PartRosetta()
+        new_rose.hpn = hpn
+        new_rose.syspn = syspn
+        new_rose.start_gpstime = at_date
+        new_rose.stop_gpstime = date2
+        session.add(new_rose)
     else:
-        rose.stop_gpstime = int(cm_utils.get_astropytime(stop_date).gps)
-    session.add(rose)
+        old_rose.stop_gpstime = at_date
+        session.add(old_rose)
+
     session.commit()
     if close_session_when_done:  # pragma: no cover
         session.close()

--- a/hera_mc/cm_utils.py
+++ b/hera_mc/cm_utils.py
@@ -389,10 +389,10 @@ def future_date():
     Returns
     -------
     Time
-        Time 300 days in the future.
+        Time 1000 days in the future.
 
     """
-    return Time.now() + TimeDelta(300, format='jd')
+    return Time.now() + TimeDelta(1000, format='jd')
 
 
 def get_stopdate(stop_date):

--- a/hera_mc/data/test_data/initialization_data_part_rosetta.csv
+++ b/hera_mc/data/test_data/initialization_data_part_rosetta.csv
@@ -1,2 +1,4 @@
 hpn,syspn,start_gpstime,stop_gptime
 SNPC000700,heraNode700Snap700,1275040818,
+SNPC000701,heraNode0Snap701,1275040818,
+SNPC000709,heraNode700Snap709,1275040818,

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 from astropy.time import Time
 from collections import OrderedDict
+from ..tests import checkWarnings
 
 from hera_mc import cm_partconnect, cm_utils, cm_handling, cm_revisions, cm_dossier, cm_active
 
@@ -132,6 +133,15 @@ def test_rosetta(mcsession, capsys):
     mcsession.add(rose)
     mcsession.commit()
     pytest.raises(ValueError, active.load_rosetta)
+    rose2 = cm_partconnect.PartRosetta()
+    rose2.hpn = 'SNPC000712'
+    rose2.syspn = 'heraNode712Snap712'
+    rose2.start_gpstime = Time('2019-07-01 01:00:00', scale='utc').gps
+    rose2.stop_gpstime = Time('2020-08-01 01:00:00', scale='utc').gps
+    mcsession.add(rose2)
+    mcsession.commit()
+    checkWarnings(cm_partconnect.update_part_rosetta,
+                  ['SNPC000712', 'heraNode712Snap712', '2020/01/02'])
 
 
 def test_update_part(parts, capsys):

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -5,11 +5,9 @@
 """Testing for `hera_mc.connections`."""
 
 import pytest
-import warnings
 import numpy as np
 from astropy.time import Time
 from collections import OrderedDict
-from ..tests import checkWarnings
 
 from hera_mc import cm_partconnect, cm_utils, cm_handling, cm_revisions, cm_dossier, cm_active
 

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -103,14 +103,28 @@ def test_rosetta(mcsession, capsys):
     print(active.rosetta['SNPC000700'])
     captured = capsys.readouterr()
     assert captured.out.strip().startswith('<SNPC000700')
-    cm_partconnect.add_part_rosetta(mcsession, 'SNPC000702', 'heraNode700Snap1', at_date)
+    cm_partconnect.update_part_rosetta('SNPC000702', 'heraNode700Snap1',
+                                       at_date, session=mcsession)
     active.load_rosetta(at_date)
     assert active.rosetta['SNPC000702'].syspn == 'heraNode700Snap1'
     stop_at = Time('2020-08-01 01:00:00', scale='utc')
-    cm_partconnect.add_part_rosetta(mcsession, 'SNPC000701', 'heraNode700Snap2', at_date, stop_at)
+    cm_partconnect.update_part_rosetta('SNPC000701', 'heraNode700Snap2',
+                                       at_date, stop_at, mcsession)
     active.load_rosetta(Time('2020-07-15 01:00:00', scale='utc'))
     assert int(active.rosetta['SNPC000701'].stop_gpstime) == 1280278818
-    # Add a test part to fail
+    cm_partconnect.update_part_rosetta('SNPC000709', 'heraNode700Snap709',
+                                       stop_at, session=mcsession)
+    assert int(active.rosetta['SNPC000709'].stop_gpstime) == 1280278818
+    # Add a test part to fail on update part
+    rose = cm_partconnect.PartRosetta()
+    rose.hpn = 'SNPC000701'
+    rose.syspn = 'heraNode0Snap701'
+    rose.start_gpstime = Time('2019-07-15 01:00:00', scale='utc').gps
+    mcsession.add(rose)
+    mcsession.commit()
+    pytest.raises(ValueError, cm_partconnect.update_part_rosetta, 'SNPC000701',
+                  'heraNode0Snap701', stop_at, None, mcsession)
+    # Add a test part to fail on load active
     rose = cm_partconnect.PartRosetta()
     rose.hpn = 'SNPC000701'
     rose.syspn = 'heraNode700Snap700'

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -139,7 +139,9 @@ def test_rosetta(mcsession, capsys):
     rose2.stop_gpstime = Time('2020-08-01 01:00:00', scale='utc').gps
     mcsession.add(rose2)
     mcsession.commit()
-    with pytest.warns(UserWarning):
+    with pytest.warns(UserWarning,
+                      match="No action taken.  <SNPC000712  -  heraNode712Snap712 ::"
+                      " 1245978018 - 1280278818> already has a valid stop date"):
         cm_partconnect.update_part_rosetta('SNPC000712', 'heraNode712Snap712',
                                            '2020/01/02', session=mcsession)
 

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -5,10 +5,10 @@
 """Testing for `hera_mc.connections`."""
 
 import pytest
+import warnings
 import numpy as np
 from astropy.time import Time
 from collections import OrderedDict
-from ..tests import checkWarnings
 
 from hera_mc import cm_partconnect, cm_utils, cm_handling, cm_revisions, cm_dossier, cm_active
 
@@ -140,8 +140,9 @@ def test_rosetta(mcsession, capsys):
     rose2.stop_gpstime = Time('2020-08-01 01:00:00', scale='utc').gps
     mcsession.add(rose2)
     mcsession.commit()
-    checkWarnings(cm_partconnect.update_part_rosetta,
-                  ['SNPC000712', 'heraNode712Snap712', '2020/01/02'])
+    with pytest.warns(UserWarning):
+        cm_partconnect.update_part_rosetta('SNPC000712', 'heraNode712Snap712',
+                                           '2020/01/02', session=mcsession)
 
 
 def test_update_part(parts, capsys):

--- a/hera_mc/tests/test_parts.py
+++ b/hera_mc/tests/test_parts.py
@@ -122,8 +122,10 @@ def test_rosetta(mcsession, capsys):
     rose.start_gpstime = Time('2019-07-15 01:00:00', scale='utc').gps
     mcsession.add(rose)
     mcsession.commit()
-    pytest.raises(ValueError, cm_partconnect.update_part_rosetta, 'SNPC000701',
-                  'heraNode0Snap701', stop_at, None, mcsession)
+    with pytest.raises(ValueError, match="Multiple rosetta relationships active"
+                       " for heraNode0Snap701"):
+        cm_partconnect.update_part_rosetta('SNPC000701', 'heraNode0Snap701',
+                                           stop_at, None, mcsession)
     # Add a test part to fail on load active
     rose = cm_partconnect.PartRosetta()
     rose.hpn = 'SNPC000701'

--- a/scripts/update_part_rosetta.py
+++ b/scripts/update_part_rosetta.py
@@ -32,9 +32,15 @@ if __name__ == '__main__':
     parser.add_argument('-q', '--query', help="Set flag if wished to be queried",
                         action='store_true')
     cm_utils.add_date_time_args(parser)
+<<<<<<< HEAD:scripts/add_part_rosetta.py
     parser.add_argument('--date2', help="Stop date (if not None)", default=None)
     parser.add_argument('--time2', help="Stop time (if not None)", default=None)
     parser.add_argument('--verbose', help="Turn verbose mode on.", action='store_true')
+=======
+    parser.add_argument('--date2', help="Stop date (if not None and hpn-syspn not existing)",
+                        default=None)
+    parser.add_argument('--time2', help="Stop time ( '' )", default=None)
+>>>>>>> changed to update rosetta:scripts/update_part_rosetta.py
     args = parser.parse_args()
 
     if args.query:
@@ -48,6 +54,11 @@ if __name__ == '__main__':
     session = db.sessionmaker()
 
     # Check for part
+<<<<<<< HEAD:scripts/add_part_rosetta.py
     if args.verbose:
         print("Adding part_rosetta {}: - {}".format(args.hpn, args.syspn))
     cm_partconnect.add_part_rosetta(session, args.hpn, args.syspn, start_date, stop_date)
+=======
+    print("Adding part_rosetta {}: - {}".format(args.hpn, args.syspn))
+    cm_partconnect.update_part_rosetta(args.hpn, args.syspn, start_date, stop_date, session)
+>>>>>>> changed to update rosetta:scripts/update_part_rosetta.py

--- a/scripts/update_part_rosetta.py
+++ b/scripts/update_part_rosetta.py
@@ -32,15 +32,9 @@ if __name__ == '__main__':
     parser.add_argument('-q', '--query', help="Set flag if wished to be queried",
                         action='store_true')
     cm_utils.add_date_time_args(parser)
-<<<<<<< HEAD:scripts/add_part_rosetta.py
     parser.add_argument('--date2', help="Stop date (if not None)", default=None)
     parser.add_argument('--time2', help="Stop time (if not None)", default=None)
     parser.add_argument('--verbose', help="Turn verbose mode on.", action='store_true')
-=======
-    parser.add_argument('--date2', help="Stop date (if not None and hpn-syspn not existing)",
-                        default=None)
-    parser.add_argument('--time2', help="Stop time ( '' )", default=None)
->>>>>>> changed to update rosetta:scripts/update_part_rosetta.py
     args = parser.parse_args()
 
     if args.query:
@@ -54,11 +48,6 @@ if __name__ == '__main__':
     session = db.sessionmaker()
 
     # Check for part
-<<<<<<< HEAD:scripts/add_part_rosetta.py
     if args.verbose:
         print("Adding part_rosetta {}: - {}".format(args.hpn, args.syspn))
     cm_partconnect.add_part_rosetta(session, args.hpn, args.syspn, start_date, stop_date)
-=======
-    print("Adding part_rosetta {}: - {}".format(args.hpn, args.syspn))
-    cm_partconnect.update_part_rosetta(args.hpn, args.syspn, start_date, stop_date, session)
->>>>>>> changed to update rosetta:scripts/update_part_rosetta.py


### PR DESCRIPTION
The earlier "add_rosetta" wasn't fully thought out with the late change to adding timed entries.  This redoes is a la apriori_antenna.  The change allows it to more easily be used in the cm_db_updates workflow.