### PR TITLE
this improves the node dossier function and fixes a hookup bug

### DIFF
--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -92,10 +92,7 @@ class Hookup(object):
             self.hookup_type = self.sysdef.find_hookup_type(
                 part_type=part.hptype, hookup_type=hookup_type)
             if part.hptype in self.sysdef.redirect_part_types[self.hookup_type]:
-                try:
-                    redirect_parts = self.sysdef.handle_redirect_part_types(part, self.active)
-                except KeyError:
-                    continue
+                redirect_parts = self.sysdef.handle_redirect_part_types(part, self.active)
                 redirect_hookup_dict = self.get_hookup_from_db(
                     hpn=redirect_parts, pol=pol, at_date=self.at_date,
                     exact_match=True, hookup_type=self.hookup_type)

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -92,7 +92,10 @@ class Hookup(object):
             self.hookup_type = self.sysdef.find_hookup_type(
                 part_type=part.hptype, hookup_type=hookup_type)
             if part.hptype in self.sysdef.redirect_part_types[self.hookup_type]:
-                redirect_parts = self.sysdef.handle_redirect_part_types(part, self.active)
+                try:
+                    redirect_parts = self.sysdef.handle_redirect_part_types(part, self.active)
+                except KeyError:
+                    continue
                 redirect_hookup_dict = self.get_hookup_from_db(
                     hpn=redirect_parts, pol=pol, at_date=self.at_date,
                     exact_match=True, hookup_type=self.hookup_type)

--- a/hera_mc/cm_sysdef.py
+++ b/hera_mc/cm_sysdef.py
@@ -124,10 +124,13 @@ class Sysdef:
         hpn_list = []
         if self.hookup_type == 'parts_hera':
             if part.hptype.lower() == 'node':
-                for conn in active.connections['down'][cm_utils.make_part_key(
-                        part.hpn, part.hpn_rev)].values():
-                    if conn.upstream_part.startswith('SNP'):
-                        hpn_list.append(conn.upstream_part)
+                try:
+                    for conn in active.connections['down'][cm_utils.make_part_key(
+                            part.hpn, part.hpn_rev)].values():
+                        if conn.upstream_part.startswith('SNP'):
+                            hpn_list.append(conn.upstream_part)
+                except KeyError:
+                    pass
         return hpn_list
 
     def find_hookup_type(self, part_type, hookup_type, set_for_class=True):

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -559,14 +559,16 @@ def formatted__which_node__string(ant_node):
     return print_str
 
 
-def node_info(node_num, session=None):
+def node_info(node_num='active', session=None):
     """
     Generate information per node.
 
     Parameters
     ----------
-    node_num : list of int or str (can be mixed)
-        Node numbers, as int or hera part number
+    node_num : list of int or str (can be mixed), or str
+        Node numbers, as int or hera part number.
+        If 'active', use list of active nodes.
+        if 'all', use list of all.
 
     Returns
     -------
@@ -576,6 +578,10 @@ def node_info(node_num, session=None):
     hu = cm_hookup.Hookup(session)
     na_from_file = node_antennas('file', session=session)
     na_from_hookup = node_antennas(hu, session=session)
+    if node_num == 'active':
+        node_num = sorted(list(na_from_hookup))
+    elif node_num == 'all':
+        node_num = sorted(list(na_from_file))
     info = {'nodes': []}
     for node in node_num:
         # Set up

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -292,6 +292,10 @@ def test_sysutil_node(capsys, mcsession):
     testhu = {'this-test': testns}
     eret = cm_sysutils._get_dict_elements('this-test', testhu, 'a', 'b')
     assert len(eret['a']) == 0
+    xa = cm_sysutils.node_info('active', mcsession)
+    assert 'N700' in xa['nodes']
+    xa = cm_sysutils.node_info('all', mcsession)
+    assert 'N00' in xa['nodes']
     testns.hookup['@<middle'] = [Namespace(upstream_part='UP', downstream_part='DN')]
     testhu = {'this-test': testns}
     eret = cm_sysutils._get_dict_elements('this-test', testhu, 'dn', 'up')

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -184,6 +184,10 @@ def test_hookup_dossier(sys_handle, capsys):
     xret = hude.get_part_from_type('b', include_revs=True,
                                    include_ports=True)
     assert xret['hu'] == 'shoe:testing<screw'
+    test_part = Namespace(hpn='ABC', hpn_rev='X', hptype='node')
+    sysdef.hookup_type = 'parts_hera'
+    hl = sysdef.handle_redirect_part_types(test_part, Namespace(connections={}))
+    assert not len(hl)
 
     # test errors
     hude = cm_dossier.HookupEntry(entry_key='testing:key', sysdef=sysdef)
@@ -282,6 +286,8 @@ def test_sysdef(sys_handle, mcsession):
 
 
 def test_sysutil_node(capsys, mcsession):
+    xni = cm_sysutils.node_info(['N91'], mcsession)
+    assert not len(xni['N91']['ants-file'])
     apn = cm_sysutils.node_antennas(session=mcsession)
     assert 'N10' in apn.keys()
     apn = cm_sysutils.node_antennas(source='hookup', session=mcsession)

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -152,7 +152,7 @@ def test_other_hookup(sys_handle, mcsession, capsys):
     x = hookup._requested_list_OK_for_cache(['B1'])
     assert x is False
     x = hookup.get_hookup_from_db('N91', 'N', 'now')
-    assert not len(x)
+    assert len(x) == 0
 
 
 def test_hookup_notes(mcsession, capsys):
@@ -187,7 +187,7 @@ def test_hookup_dossier(sys_handle, capsys):
     test_part = Namespace(hpn='ABC', hpn_rev='X', hptype='node')
     sysdef.hookup_type = 'parts_hera'
     hl = sysdef.handle_redirect_part_types(test_part, Namespace(connections={}))
-    assert not len(hl)
+    assert len(hl) == 0
 
     # test errors
     hude = cm_dossier.HookupEntry(entry_key='testing:key', sysdef=sysdef)

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -151,6 +151,8 @@ def test_other_hookup(sys_handle, mcsession, capsys):
     hookup.hookup_list_to_cache = ['A1']
     x = hookup._requested_list_OK_for_cache(['B1'])
     assert x is False
+    x = hookup.get_hookup_from_db('N91', 'N', 'now')
+    assert not len(x)
 
 
 def test_hookup_notes(mcsession, capsys):

--- a/scripts/dossier.py
+++ b/scripts/dossier.py
@@ -20,7 +20,8 @@ parser.add_argument('view', nargs='?', help="Views are:  {}.  Need first letter 
                     ".format(', '.join(all_views.values())), default='parts')
 # set values for 'action' to use
 parser.add_argument('-p', '--hpn', help="Part number or portion thereof, csv list. "
-                    "If view is 'node', this may be ints or a hyphen-range of ints (e.g. '0-3')")
+                    "If view is 'node', this may be ints or a hyphen-range of ints (e.g. '0-3')"
+                    "or 'active'/'all'", default=None)
 parser.add_argument('-r', '--revision',
                     help="Revision for hpn. Typically don't change from default.",
                     default=None)
@@ -69,7 +70,10 @@ if args.list_columns:
             print('\t{:30s}\t{}'.format(col, blank.col_hdr[col]))
 elif view == 'node':
     from hera_mc import cm_sysutils
-    args.hpn = cm_utils.listify(args.hpn)
+    if args.hpn is None:
+        args.hpn = 'active'
+    elif args.hpn not in ['active', 'all']:
+        args.hpn = cm_utils.listify(args.hpn)
     node_info = cm_sysutils.node_info(args.hpn, session)
     cm_sysutils.print_node(node_info)
 elif view == 'revisions':


### PR DESCRIPTION
This adds useful node functionality to the dossier.py to leave off an argument to get all active nodes.  It also fixes a bug that cropped up in cm_hookup.  Typing `dossier.py node` gives a table of connections, MACs, IPs, and connected antennas etc.