### PR TITLE
added using ints for dossier node

### DIFF
--- a/hera_mc/cm_utils.py
+++ b/hera_mc/cm_utils.py
@@ -172,16 +172,16 @@ def stringify(X):
     return str(X)
 
 
-def listify(X, None_as_list=False, prefix=None, padding=None):
+def listify(to_list, None_as_list=False, prefix=None, padding=None):
     """
     "Listify" the input, hopefully sensibly.
 
     Parameters
     ----------
-    X
+    to_list
         Thing to be listified.
     None_as_list : bool
-        If False return None, otherwise return [None]
+        If False return None if to_list is None, otherwise return [None]
     prefix : str or None
         If str, it will be prepended to every element in list
     padding : int or None
@@ -192,33 +192,33 @@ def listify(X, None_as_list=False, prefix=None, padding=None):
     List or None
 
     """
-    if X is None:
+    if to_list is None:
         if None_as_list:
             return [None]
         else:
             return None
-    if isinstance(X, str):
-        if '-' in X:
+    if isinstance(to_list, str):
+        if '-' in to_list:
             try:
-                start, stop = [int(_x) for _x in X.split('-')]
+                start, stop = [int(_x) for _x in to_list.split('-')]
                 this_list = list(range(int(start), int(stop) + 1))
             except ValueError:
-                this_list = X.split(',')
+                this_list = to_list.split(',')
                 padding = None
         else:
             try:
-                this_list = [int(_x) for _x in X.split(',')]
+                this_list = [int(_x) for _x in to_list.split(',')]
             except ValueError:
-                this_list = X.split(',')
+                this_list = to_list.split(',')
                 padding = None
         if prefix is None:
             return this_list
         if isinstance(padding, int):
             return ['{}{:0{pad}d}'.format(prefix, x, pad=padding) for x in this_list]
         return ['{}{}'.format(prefix, x) for x in this_list]
-    if isinstance(X, list):
-        return X
-    return [X]
+    if isinstance(to_list, list):
+        return to_list
+    return [to_list]
 
 
 def match_list(a_obj, b_obj, case_type=None):

--- a/hera_mc/cm_utils.py
+++ b/hera_mc/cm_utils.py
@@ -172,7 +172,7 @@ def stringify(X):
     return str(X)
 
 
-def listify(X, None_as_list=False):
+def listify(X, None_as_list=False, prefix=None, padding=None):
     """
     "Listify" the input, hopefully sensibly.
 
@@ -182,6 +182,10 @@ def listify(X, None_as_list=False):
         Thing to be listified.
     None_as_list : bool
         If False return None, otherwise return [None]
+    prefix : str or None
+        If str, it will be prepended to every element in list
+    padding : int or None
+        If int, every integer element will be zero-padded to that length
 
     Returns
     -------
@@ -194,13 +198,24 @@ def listify(X, None_as_list=False):
         else:
             return None
     if isinstance(X, str):
-        if ',' in X:
-            return X.split(',')
-        elif '-' in X:
-            start, stop = X.split('-')
-            return list(range(int(start), int(stop) + 1))
+        if '-' in X:
+            try:
+                start, stop = [int(_x) for _x in X.split('-')]
+                this_list = list(range(int(start), int(stop) + 1))
+            except ValueError:
+                this_list = X.split(',')
+                padding = None
         else:
-            return [X]
+            try:
+                this_list = [int(_x) for _x in X.split(',')]
+            except ValueError:
+                this_list = X.split(',')
+                padding = None
+        if prefix is None:
+            return this_list
+        if isinstance(padding, int):
+            return ['{}{:0{pad}d}'.format(prefix, x, pad=padding) for x in this_list]
+        return ['{}{}'.format(prefix, x) for x in this_list]
     if isinstance(X, list):
         return X
     return [X]

--- a/hera_mc/tests/test_cm_utils.py
+++ b/hera_mc/tests/test_cm_utils.py
@@ -76,6 +76,12 @@ def test_listify(input, expected):
     assert x is None
     x = cm_utils.listify(None, None_as_list=True)
     assert x[0] is None
+    x = cm_utils.listify('0-4', prefix='Test')
+    assert x[1] == 'Test1'
+    x = cm_utils.listify('0,3,4', prefix='Test', padding=3)
+    assert x[2] == 'Test004'
+    x = cm_utils.listify('N0-A', prefix='Test', padding=3)
+    assert x[0] == 'TestN0-A'
 
 
 def test_match_list():

--- a/hera_mc/tests/test_cm_utils.py
+++ b/hera_mc/tests/test_cm_utils.py
@@ -76,12 +76,12 @@ def test_listify(input, expected):
     assert x is None
     x = cm_utils.listify(None, None_as_list=True)
     assert x[0] is None
-    x = cm_utils.listify('0-4', prefix='Test')
-    assert x[1] == 'Test1'
+    x = cm_utils.listify('0-3', prefix='Test')
+    assert x == ['Test0', 'Test1', 'Test2', 'Test3']
     x = cm_utils.listify('0,3,4', prefix='Test', padding=3)
-    assert x[2] == 'Test004'
+    assert x == ['Test000', 'Test003', 'Test004']
     x = cm_utils.listify('N0-A', prefix='Test', padding=3)
-    assert x[0] == 'TestN0-A'
+    assert x == ['TestN0-A']
 
 
 def test_match_list():

--- a/scripts/dossier.py
+++ b/scripts/dossier.py
@@ -73,7 +73,11 @@ elif view == 'node':
     if args.hpn is None:
         args.hpn = 'active'
     elif args.hpn not in ['active', 'all']:
-        args.hpn = cm_utils.listify(args.hpn)
+        if args.hpn[0] == 'N':
+            prefix = None
+        else:
+            prefix = 'N'
+        args.hpn = cm_utils.listify(args.hpn, prefix=prefix, padding=2)
     node_info = cm_sysutils.node_info(args.hpn, session)
     cm_sysutils.print_node(node_info)
 elif view == 'revisions':


### PR DESCRIPTION
This implements what I had intended to do earlier (and included in the help) to allow nodes to be specified by just integers rather than node hpn in the 'dossier.py' node script.