### PR TITLE
split send-email

### DIFF
--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -60,15 +60,15 @@ def test_watch_dog(mcsession):
     mcsession.commit()
     msg = watch_dog.node_temperature(at_date=None, at_time=0.0,
                                      temp_threshold=45.0, time_threshold=10000.0,
-                                     To=['test@hera.edu'], skip_send=True, session=mcsession)
+                                     To=['test@hera.edu'], testing=True, session=mcsession)
     assert msg.startswith("From: hera@lists.berkeley.edu")
     msg = watch_dog.node_temperature(at_date='2020/09/19', at_time=0.0,
                                      temp_threshold=45.0, time_threshold=10000.0,
-                                     To=['test@hera.edu'], skip_send=True, session=mcsession)
+                                     To=['test@hera.edu'], testing=True, session=mcsession)
     assert msg.startswith("From: hera@lists.berkeley.edu")
     msg = watch_dog.node_temperature(at_date='2020/09/19', at_time=0.0,
                                      temp_threshold=45.0, time_threshold=0.0,
-                                     To=['test@hera.edu'], skip_send=True, session=mcsession)
+                                     To=['test@hera.edu'], testing=True, session=mcsession)
     assert msg is None
 
 

--- a/hera_mc/watch_dog.py
+++ b/hera_mc/watch_dog.py
@@ -116,7 +116,7 @@ def hosts_ethers(path='/etc', To=None, testing=False):
     meth, neth = read_hosts_ethers_file('ethers', host=hostname, path=path, testing=testing)
     if 'Error' in meth.keys():
         return send_message(meth['Subject'], meth['Message'], to_addr=To, skip_send=testing)
-    print("Now need to do the actually checking.")
+    print("Now need to do the actual checking.")
 
 
 def node_temperature(at_date=None, at_time=0.0,

--- a/hera_mc/watch_dog.py
+++ b/hera_mc/watch_dog.py
@@ -6,7 +6,7 @@
 """System watch-dogs."""
 
 
-def send_message(subject, msg, to_addr=None, from_addr='hera@lists.berkeley.edu', skip_send=False):
+def send_email(subject, msg, to_addr=None, from_addr='hera@lists.berkeley.edu', skip_send=False):
     """
     Send an email message, unless skip_send is True (for testing).
 
@@ -129,4 +129,4 @@ def node_temperature(at_date=None, at_time=0.0,
                 htlist.append(ht)
             msg += "\n\t {:02d}   {}".format(node_num, '  '.join(htlist))
     if msg != msg_header:
-        return send_message(msg_header.splitlines()[0], msg, To, skip_send=testing)
+        return send_email(msg_header.splitlines()[0], msg, To, skip_send=testing)


### PR DESCRIPTION
This was going to be a bigger PR to add some other watch dogs that I think are somewhat deprecated in the new scheme.  However, I did want to keep the "mail" method broken out from the initial, so this is to do that.