### PR TITLE
fix accidental nodeControl reference change

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -1821,7 +1821,7 @@ class MCSession(Session):
             if not dryrun:  # pragma: no cover
                 import nodeControl
 
-                node_controller = nodeControl.node.NodeControl(
+                node_controller = nodeControl.NodeControl(
                     nodeID, serverAddress=nodeServerAddress)
                 getattr(node_controller,
                         node.power_command_part_dict[partname])(command)


### PR DESCRIPTION
This fixes a bug that was caused by copy/paste errors when changing the imports in `mc_session.py` in PR #518. This part of the code is control code, so it is not covered by tests either on CI or onsite so was only caught from cronjob errors.