### PR TITLE
Allow jones-pol strings (Jnn and Jee) to be used for ingesting ant_metrics

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4032,7 +4032,7 @@ class MCSession(Session):
             Observation identification number.
         ant : int
             Antenna number.
-        pol : str ('x', 'y', 'n', or 'e')
+        pol : str ('x', 'y', 'n', 'e', 'Jnn', 'Jee')
             Polarization name.
         metric : str
             Metric name, foreign key into `metric_list`.

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4032,7 +4032,7 @@ class MCSession(Session):
             Observation identification number.
         ant : int
             Antenna number.
-        pol : str ('x', 'y', 'n', 'e', 'Jnn', 'Jee')
+        pol : str ('x', 'y', 'n', 'e', 'jnn', or 'jee')
             Polarization name.
         metric : str
             Metric name, foreign key into `metric_list`.
@@ -4053,7 +4053,7 @@ class MCSession(Session):
         ----------
         ant : int or list of integers
             Antenna number. Defaults to returning all antennas.
-        pol : str ('x', 'y', 'n', or 'e'), or list
+        pol : str ('x', 'y', 'n', 'e', 'jnn', or 'jee'), or list
             Polarization. Defaults to returning all pols.
         metric : str or list of strings
             Metric name. Defaults to returning all metrics.

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -93,7 +93,7 @@ class AntMetrics(MCDeclarativeBase):
         except ValueError:
             raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
         pol = pol.lower()
-        if pol not in ('x', 'y', 'n', 'e', 'Jnn', 'Jee'):
+        if pol not in ('x', 'y', 'n', 'e', 'jnn', 'jee'):
             raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
         if not isinstance(metric, str):
             raise ValueError('metric must be string.')

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -88,11 +88,7 @@ class AntMetrics(MCDeclarativeBase):
             raise ValueError('obsid must be an integer.')
         if not isinstance(ant, int):
             raise ValueError('antenna must be an integer.')
-        try:
-            pol = str(pol)
-        except ValueError:
-            raise ValueError(f'pol={pol} not a string in ("x", "y", "n", "e", "jnn", "jee").')
-        pol = pol.lower()
+        pol = str(pol).lower()
         if pol not in ('x', 'y', 'n', 'e', 'jnn', 'jee'):
             raise ValueError(f'pol={pol} not a string in ("x", "y", "n", "e", "jnn", "jee").')
         if not isinstance(metric, str):

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -29,7 +29,7 @@ class AntMetrics(MCDeclarativeBase):
     ant : Integer Column
         Antenna number (int >= 0)
     pol : String Column
-        Polarization ('x', 'y', 'n', 'e', 'Jnn', or 'Jee')
+        Polarization ('x', 'y', 'n', 'e', 'jnn', or 'jee')
     metric : String Column
         Name of metric
     mc_time : BigInteger Column
@@ -73,7 +73,7 @@ class AntMetrics(MCDeclarativeBase):
             observation identification number.
         ant: integer
             antenna number
-        pol: string ('x', 'y', 'n', 'e', 'Jnn', or 'Jee')
+        pol: string ('x', 'y', 'n', 'e', 'jnn', or 'jee')
             polarization
         metric: string
             metric name
@@ -91,10 +91,10 @@ class AntMetrics(MCDeclarativeBase):
         try:
             pol = str(pol)
         except ValueError:
-            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "Jnn", "Jee").')
+            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
         pol = pol.lower()
         if pol not in ('x', 'y', 'n', 'e', 'Jnn', 'Jee'):
-            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "Jnn", "Jee").')
+            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
         if not isinstance(metric, str):
             raise ValueError('metric must be string.')
         if not isinstance(db_time, Time):

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -91,10 +91,10 @@ class AntMetrics(MCDeclarativeBase):
         try:
             pol = str(pol)
         except ValueError:
-            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
+            raise ValueError(f'pol={pol} not a string in ("x", "y", "n", "e", "jnn", "jee").')
         pol = pol.lower()
         if pol not in ('x', 'y', 'n', 'e', 'jnn', 'jee'):
-            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "jnn", "jee").')
+            raise ValueError(f'pol={pol} not a string in ("x", "y", "n", "e", "jnn", "jee").')
         if not isinstance(metric, str):
             raise ValueError('metric must be string.')
         if not isinstance(db_time, Time):

--- a/hera_mc/qm.py
+++ b/hera_mc/qm.py
@@ -29,7 +29,7 @@ class AntMetrics(MCDeclarativeBase):
     ant : Integer Column
         Antenna number (int >= 0)
     pol : String Column
-        Polarization ('x', 'y', 'n', or 'e')
+        Polarization ('x', 'y', 'n', 'e', 'Jnn', or 'Jee')
     metric : String Column
         Name of metric
     mc_time : BigInteger Column
@@ -73,7 +73,7 @@ class AntMetrics(MCDeclarativeBase):
             observation identification number.
         ant: integer
             antenna number
-        pol: string ('x', 'y', 'n', or 'e')
+        pol: string ('x', 'y', 'n', 'e', 'Jnn', or 'Jee')
             polarization
         metric: string
             metric name
@@ -91,10 +91,10 @@ class AntMetrics(MCDeclarativeBase):
         try:
             pol = str(pol)
         except ValueError:
-            raise ValueError('pol must be string "x", "y", "n", or "e".')
+            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "Jnn", "Jee").')
         pol = pol.lower()
-        if pol not in ('x', 'y', 'n', 'e'):
-            raise ValueError('pol must be string "x", "y", "n", or "e".')
+        if pol not in ('x', 'y', 'n', 'e', 'Jnn', 'Jee'):
+            raise ValueError(f'pol="{pol}" not a string in ("x", "y", "n", "e", "Jnn", "Jee").')
         if not isinstance(metric, str):
             raise ValueError('metric must be string.')
         if not isinstance(db_time, Time):

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -77,7 +77,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
 @pytest.mark.parametrize(
     'ant,pol,metric,val,err_msg',
     [('0', 'x', 'test', 4.5, 'antenna must be an integer.'),
-     (0, u'\xff', 'test', 4.5, 'pol must be string "x"'),
+     (0, u'\xff', 'test', 4.5, 'pol='),
      (0, 'Q', 'test', 4.5, 'pol must be string'),
      (0, 'x', 4, 4.5, 'metric must be string.'),
      (0, 'x', 'test', 'value', 'val must be castable as float'),

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -77,6 +77,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
 @pytest.mark.parametrize(
     'ant,pol,metric,val,err_msg',
     [('0', 'x', 'test', 4.5, 'antenna must be an integer.'),
+     (0, 5, 'test', 4.5, 'pol='),
      (0, u'\xff', 'test', 4.5, 'pol='),
      (0, 'Q', 'test', 4.5, 'pol='),
      (0, 'x', 4, 4.5, 'metric must be string.'),

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -78,7 +78,7 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
     'ant,pol,metric,val,err_msg',
     [('0', 'x', 'test', 4.5, 'antenna must be an integer.'),
      (0, u'\xff', 'test', 4.5, 'pol='),
-     (0, 'Q', 'test', 4.5, 'pol must be string'),
+     (0, 'Q', 'test', 4.5, 'pol='),
      (0, 'x', 4, 4.5, 'metric must be string.'),
      (0, 'x', 'test', 'value', 'val must be castable as float'),
      ]


### PR DESCRIPTION
This fixes an error that was coming up in RTP at this step: https://github.com/HERA-Team/hera_pipelines/blob/093a43bccf5bc5a41003fbb8710c37cd6f79a59f/pipelines/h4c/rtp/v1/stage_1_task_scripts/do_ANT_METRICS.sh#L64

Here's the `pdb`:
```
(RTP) obs@qmaster:~/rtp_makeflow/2459271$ python -m pdb /home/obs/anaconda/envs/RTP/bin/add_qm_metrics.py --type=ant /mnt/sn1/zen.2459271.50303.sum.ant_metrics.hdf5
> /home/obs/anaconda/envs/RTP/bin/add_qm_metrics.py(8)<module>()
-> """
(Pdb) c
Traceback (most recent call last):
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/pdb.py", line 1699, in main
    pdb._runscript(mainpyfile)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/pdb.py", line 1568, in _runscript
    self.run(statement)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/bdb.py", line 578, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/obs/anaconda/envs/RTP/bin/add_qm_metrics.py", line 8, in <module>
    """
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/mc_session.py", line 4249, in ingest_metrics_file
    self.add_ant_metric(obsid, ant, pol, metric, val)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/mc_session.py", line 4045, in add_ant_metric
    self.add(AntMetrics.create(obsid, ant, pol, metric, db_time, val))
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/qm.py", line 97, in create
    raise ValueError('pol must be string "x", "y", "n", or "e".')
ValueError: pol must be string "x", "y", "n", or "e".
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> /home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/qm.py(97)create()
-> raise ValueError('pol must be string "x", "y", "n", or "e".')
(Pdb) pol
'jnn'
```