### PR TITLE
Get region

### DIFF
--- a/hera_mc/geo_sysdef.py
+++ b/hera_mc/geo_sysdef.py
@@ -57,7 +57,9 @@ def _get_region(this_ant):
         Antenna number for which to check.
     """
     prefix = ''
-    if not isinstance(this_ant, int):
+    try:
+        this_ant = int(this_ant)
+    except ValueError:
         peeled = cm_utils.peel_key(this_ant, 'NPR')
         this_ant = peeled[0]
         prefix = peeled[1].upper()
@@ -78,7 +80,8 @@ def ant_region(ants):
     """
     Provide the region of an antenna or list of antennas.
 
-    If a list, it will return a list, otherwise it will return a str.
+    If a list (list, tuple, set, numpy array), it will return a list,
+    otherwise it will return a str.
     Note that the regions are:  N, E, W, A, B for
         North "tridrant"
         East  "
@@ -88,13 +91,21 @@ def ant_region(ants):
 
     Parameter
     ---------
-    ants : str, int or list
+    ants : str, number or list (list, tuple, set, numpy array)
             Antenna number or HERA part number of antenna.
+
+    Return
+    ------
+    str or list-of-str : single character region designations
     """
-    return_as = 'list'
-    if not isinstance(ants, list):
+    try:
+        ants = [int(ants)]
         return_as = 'str'
+    except ValueError:
         ants = [ants]
+        return_as = 'str'
+    except TypeError:
+        return_as = 'list'
     found_regions = [_get_region(_a) for _a in ants]
     if return_as == 'str':
         return found_regions[0]

--- a/hera_mc/geo_sysdef.py
+++ b/hera_mc/geo_sysdef.py
@@ -4,6 +4,7 @@
 
 """Contains geographic location information and methods."""
 import os.path
+from . import cm_utils
 
 from .data import DATA_PATH
 
@@ -41,6 +42,63 @@ region = {'herahexw': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
           'heraringa': [325, 326, 327, 330, 331, 334, 335, 338, 339, 342, 343, 344],
           'heraringb': [320, 321, 322, 323, 324, 328, 329, 332, 333, 336, 337,
                         340, 341, 345, 346, 347, 348, 349]}
+
+
+def _get_region(this_ant):
+    """
+    Properly handle a single entry for finding a region.
+
+    If a full HERA part number is given and is for a ring, it will issue a
+    warning if the prefix given and the ring don't match.
+
+    Parameter
+    ---------
+    this_ant : str or int
+        Antenna number for which to check.
+    """
+    prefix = ''
+    if not isinstance(this_ant, int):
+        peeled = cm_utils.peel_key(this_ant, 'NPR')
+        this_ant = peeled[0]
+        prefix = peeled[1].upper()
+    for this_region, region_list in region.items():
+        if this_ant in region_list:
+            val = this_region[-1].upper()
+            break
+    else:
+        raise ValueError(f"{this_ant} is not valid antenna.")
+    if val in ['A', 'B'] and len(prefix) == 2:
+        if val != prefix[1]:
+            import warnings
+            warnings.warn(f"{prefix} does not match region {val}")
+    return val
+
+
+def ant_region(ants):
+    """
+    Provide the region of an antenna or list of antennas.
+
+    If a list, it will return a list, otherwise it will return a str.
+    Note that the regions are:  N, E, W, A, B for
+        North "tridrant"
+        East  "
+        West  "
+        A ring (inner)
+        B ring (outer)
+
+    Parameter
+    ---------
+    ants : str, int or list
+            Antenna number or HERA part number of antenna.
+    """
+    return_as = 'list'
+    if not isinstance(ants, list):
+        return_as = 'str'
+        ants = [ants]
+    found_regions = [_get_region(_a) for _a in ants]
+    if return_as == 'str':
+        return found_regions[0]
+    return found_regions
 
 
 def read_nodes():

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -39,6 +39,15 @@ def test_geo_sysdef():
     assert int(a['HH123']['E']) == 540945
 
 
+def test_geo_regions():
+    pytest.raises(ValueError, geo_sysdef.ant_region, 1000)
+    with pytest.warns(UserWarning, match="HH does not match region A"):
+        r = geo_sysdef.ant_region('HH325')
+    assert r == 'A'
+    r = geo_sysdef.ant_region(['HH0'])
+    assert r[0] == 'W'
+
+
 def test_update_new(mcsession, geo_handle):
     nte = 'HH_new_test_element'
     data = [[nte, 'station_name', nte],

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -42,10 +42,12 @@ def test_geo_sysdef():
 def test_geo_regions():
     pytest.raises(ValueError, geo_sysdef.ant_region, 1000)
     with pytest.warns(UserWarning, match="HH does not match region A"):
-        r = geo_sysdef.ant_region('HH325')
-    assert r == 'A'
-    r = geo_sysdef.ant_region(['HH0'])
-    assert r[0] == 'W'
+        ret = geo_sysdef.ant_region('HH325')
+    assert ret == 'A'
+    testing = [123, '123', 'HH123', 'A123']
+    ret = geo_sysdef.ant_region(testing)
+    for r in ret:
+        assert r == 'W'
 
 
 def test_update_new(mcsession, geo_handle):

--- a/scripts/cm_region.py
+++ b/scripts/cm_region.py
@@ -1,0 +1,21 @@
+#! /usr/bin/env python
+# -*- mode: python; coding: utf-8 -*-
+# Copyright 2016 the HERA Collaboration
+# Licensed under the 2-clause BSD license.
+
+"""
+Script to check region(s) of a list of antenna(s).
+"""
+
+import argparse
+from hera_mc import geo_sysdef
+
+parser = argparse.ArgumentParser()
+parser.add_argument('ants', help="Antenna or list of antennas.")
+args = parser.parse_args()
+
+args.ants = args.ants.split(',')
+regions = geo_sysdef.ant_region(args.ants)
+
+for this_ant, this_region in zip(args.ants, regions):
+    print(f"{this_ant} --> {this_region}")


### PR DESCRIPTION
This adds code to return the "region" of an antenna or antenna list.  The regions are [N, E, W] for the core antennas and [A, B] for the outriggers (A is the inner ring, B the outer).  Query inputs can be 123, '123', 'HH123', 'A123', etc. If given a list it returns a list, else it returns a string.  If given a part name ('HA325') for an outrigger antenna it will check the prefix and issue a warning if not in agreement.