### PR TITLE
Allow for updates to qm metric tables

### DIFF
--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -4618,7 +4618,7 @@ class MCSession(Session):
 
     def add_ant_metric(self, obsid, ant, pol, metric, val):
         """
-        Add a new antenna metric to the M&C database.
+        Add a new antenna metric or update an existing metric.
 
         Parameters
         ----------
@@ -4636,7 +4636,8 @@ class MCSession(Session):
         """
         db_time = self.get_current_db_time()
 
-        self.add(AntMetrics.create(obsid, ant, pol, metric, db_time, val))
+        obj_list = [AntMetrics.create(obsid, ant, pol, metric, db_time, val)]
+        self._insert_ignoring_duplicates(AntMetrics, obj_list, update=True)
 
     def get_ant_metric(self, ant=None, pol=None, metric=None, starttime=None,
                        stoptime=None):
@@ -4681,7 +4682,7 @@ class MCSession(Session):
 
     def add_array_metric(self, obsid, metric, val):
         """
-        Add a new array metric to the M&C database.
+        Add a new array metric or update an existing metric.
 
         Parameters
         ----------
@@ -4695,7 +4696,8 @@ class MCSession(Session):
         """
         db_time = self.get_current_db_time()
 
-        self.add(ArrayMetrics.create(obsid, metric, db_time, val))
+        obj_list = [ArrayMetrics.create(obsid, metric, db_time, val)]
+        self._insert_ignoring_duplicates(ArrayMetrics, obj_list, update=True)
 
     def get_array_metric(self, metric=None, starttime=None, stoptime=None):
         """

--- a/hera_mc/tests/test_qm.py
+++ b/hera_mc/tests/test_qm.py
@@ -44,11 +44,21 @@ def test_AntMetrics(mcsession, pol_x, pol_y):
 
     # now the tests
     test_session.add_ant_metric(obsid, 0, pol_x, 'test', 4.5)
+    test_session.commit()
     r = test_session.get_ant_metric(metric='test')
     assert len(r) == 1
     assert r[0].antpol == (0, pol_x)
     assert r[0].metric == 'test'
     assert r[0].val == 4.5
+
+    # test that updating works
+    test_session.add_ant_metric(obsid, 0, pol_x, 'test', 4.3)
+    test_session.commit()
+    r = test_session.get_ant_metric(metric='test')
+    assert len(r) == 1
+    assert r[0].antpol == (0, pol_x)
+    assert r[0].metric == 'test'
+    assert r[0].val == 4.3
 
     # Test more exciting queries
     test_session.add_ant_metric(obsid, 0, pol_y, 'test', 2.5)
@@ -152,9 +162,17 @@ def test_ArrayMetrics(mcsession):
 
     # now the tests
     test_session.add_array_metric(obsid, 'test', 6.2)
+    test_session.commit()
     r = test_session.get_array_metric()
     assert r[0].metric == 'test'
     assert r[0].val == 6.2
+
+    # test that updating works
+    test_session.add_array_metric(obsid, 'test', 6.5)
+    test_session.commit()
+    r = test_session.get_array_metric()
+    assert r[0].metric == 'test'
+    assert r[0].val == 6.5
 
     # Test more exciting queries
     test_session.add_array_metric(obsid + 10, 'test', 2.5)


### PR DESCRIPTION
To prevent errors when RTP is re-run.

@jsdillon reported that re-running RTP resulted in the error pasted below. This PR should fix this problem.

```
add_qm_metrics.py --type=ant /mnt/sn1/2459289/zen.2459289.27658.sum.ant_metrics.hdf5
Traceback (most recent call last):
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1257, in _execute_context
    cursor, statement, parameters, context
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 898, in do_executemany
    cursor.executemany(statement, parameters)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "ant_metrics_pkey"
DETAIL:  Key (obsid, ant, pol, metric)=(1299868709, 0, jee, ant_metrics_corr) already exists.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/home/obs/anaconda/envs/RTP/bin/add_qm_metrics.py", line 21, in <module>
    session.ingest_metrics_file(f, args.type)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/mc_session.py", line 4247, in ingest_metrics_file
    self.check_metric_desc(metric)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/mc_session.py", line 4201, in check_metric_desc
    r = self.get_metric_desc(metric=metric)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/hera_mc/mc_session.py", line 4189, in get_metric_desc
    return self.query(MetricList).filter(*args).all()
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3373, in all
    return list(self)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/query.py", line 3534, in __iter__
    self.session._autoflush()
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1633, in _autoflush
    util.raise_(e, with_traceback=sys.exc_info()[2])
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1622, in _autoflush
    self.flush()
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2540, in flush
    self._flush(objects)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2682, in _flush
    transaction.rollback(_capture_exception=True)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    with_traceback=exc_tb,
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2642, in _flush
    flush_context.execute()
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/unitofwork.py", line 422, in execute
    rec.execute(self)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/unitofwork.py", line 589, in execute
    uow,
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 245, in save_obj
    insert,
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 1083, in _emit_insert_statements
    c = cached_connections[connection].execute(statement, multiparams)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
    return meth(self, multiparams, params)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 298, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1130, in _execute_clauseelement
    distilled_params,
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1317, in _execute_context
    e, statement, parameters, cursor, context
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1511, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1257, in _execute_context
    cursor, statement, parameters, context
  File "/home/obs/anaconda/envs/RTP/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 898, in do_executemany
    cursor.executemany(statement, parameters)
sqlalchemy.exc.IntegrityError: (raised as a result of Query-invoked autoflush; consider using a session.no_autoflush block if this flush is occurring prematurely)
(psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "ant_metrics_pkey"
DETAIL:  Key (obsid, ant, pol, metric)=(1299868709, 0, jee, ant_metrics_corr) already exists.
[SQL: INSERT INTO ant_metrics (obsid, ant, pol, metric, mc_time, val) VALUES (%(obsid)s, %(ant)s, %(pol)s, %(metric)s, %(mc_time)s, %(val)s)]
[parameters: ({'obsid': 1299868709, 'ant': 0, 'pol': 'jee', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.008987202937723052}, {'obsid': 1299868709, 'ant': 0, 'pol': 'jnn', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.00794362049579303}, {'obsid': 1299868709, 'ant': 1, 'pol': 'jee', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.008122373621746072}, {'obsid': 1299868709, 'ant': 1, 'pol': 'jnn', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.007646005093638296}, {'obsid': 1299868709, 'ant': 100, 'pol': 'jee', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.6697689320719513}, {'obsid': 1299868709, 'ant': 100, 'pol': 'jnn', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.12433898274312609}, {'obsid': 1299868709, 'ant': 101, 'pol': 'jee', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.7015646194463248}, {'obsid': 1299868709, 'ant': 101, 'pol': 'jnn', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.7097414143141717}  ... displaying 10 of 175 total bound parameter sets ...  {'obsid': 1299868709, 'ant': 99, 'pol': 'jee', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.6245627658159373}, {'obsid': 1299868709, 'ant': 99, 'pol': 'jnn', 'metric': 'ant_metrics_corr', 'mc_time': 1300470417, 'val': 0.6725534149995414})]
(Background on this error at: http://sqlalche.me/e/13/gkpj)
```