### PR TITLE
Cminfo improve

### DIFF
--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -14,34 +14,6 @@ REDIS_CMINFO_HASH = 'cminfo'
 REDIS_CORR_HASH = 'corr:map'
 
 
-def snap_part_to_host_input(part):
-    """
-    Parse a part string for the putative hostname and adc number.
-
-    If a redis session is supplied and key available it returns the hostname, otherwise
-    it returns the SNAP name.  If None, returns the SNAP name.  An example part is
-    'e2>SNPC000008'
-
-    Parameters
-    ----------
-    part : str
-        port>snap part string as returned by cminfo
-    redis_info : None or str
-        If str and the key is available it returns the hostname, otherwise SNAP name
-        If None, returns the SNAP name
-
-    Returns
-    -------
-    hostname : str
-        hostname as parsed from input 'part' and redis
-    adc_num : str
-        port ADC number, as parsed from input 'part'
-    """
-    adc, hostname = part.split('>')
-    adc_num = int(adc[1:]) // 2  # divide by 2 because ADC is in demux 2
-    return hostname, adc_num
-
-
 def cminfo_redis_snap(cminfo):
     """
     Build a dictionary of correlator mappings.

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -56,8 +56,9 @@ def cminfo_redis_snap(cminfo):
             all_snap_inputs[snap_hostname].append(snap_input)
             try:  # if already present make sure it agrees
                 if snap_to_serial[snap_hostname] != snap_snr[_i]:
-                    msg = "{} inconsistent: {}  !=  {}".format(
-                          snap_hostname, snap_to_serial[snap_hostname], snap_snr[_i])
+                    msg = "{} inconsistent for antpol {}{}: {}  !=  {}".format(
+                          snap_hostname, ant, pol,
+                          snap_to_serial[snap_hostname], snap_snr[_i])
                     raise ValueError(msg)
             except KeyError:  # if not present, add it
                 snap_to_serial[snap_hostname] = snap_snr[_i]

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -56,9 +56,11 @@ def cminfo_redis_snap(cminfo):
             all_snap_inputs[snap_hostname].append(snap_input)
             try:  # if already present make sure it agrees
                 if snap_to_serial[snap_hostname] != snap_snr[_i]:
-                    msg = "{} inconsistent for antpol {}{}: {}  !=  {}".format(
-                          snap_hostname, ant, pol,
-                          snap_to_serial[snap_hostname], snap_snr[_i])
+                    msg = 'Snap hostname-to-serial inconsistent:\n'
+                    msg += '\tCurrent for antpol {}{} -> hostname={}, serial={}\n'.format(
+                        ant, pol, snap_hostname, snap_snr[_i])
+                    msg += '\tStored -> hostname={}, serial={}'.format(
+                        snap_hostname, snap_to_serial[snap_hostname])
                     raise ValueError(msg)
             except KeyError:  # if not present, add it
                 snap_to_serial[snap_hostname] = snap_snr[_i]

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -54,9 +54,11 @@ def cminfo_redis_snap(cminfo):
             snap_to_ant[snap_hostname][channel] = name + pol.upper()
             all_snap_inputs.setdefault(snap_hostname, [])
             all_snap_inputs[snap_hostname].append(snap_input)
-            try:  # if present, check if hostnames are the same between polarizations.
+            try:  # if already present make sure it agrees
                 if snap_to_serial[snap_hostname] != snap_snr[_i]:
-                    warnings.warn(f"snap_hostname {snap_hostname} differs between inputs")
+                    msg = "{} inconsistent: {}  !=  {}".format(
+                          snap_hostname, snap_to_serial[snap_hostname], snap_snr[_i])
+                    raise ValueError(msg)
             except KeyError:  # if not present, add it
                 snap_to_serial[snap_hostname] = snap_snr[_i]
 

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -52,9 +52,14 @@ def cminfo_redis_snap(cminfo):
             ant_to_snap[ant][pol] = {'host': snap_hostname, 'channel': channel}
             snap_to_ant.setdefault(snap_hostname, [None] * 6)
             snap_to_ant[snap_hostname][channel] = name + pol.upper()
-            snap_to_serial[snap_hostname] = snap_snr[_i]  # This can/does overwrite per pol
             all_snap_inputs.setdefault(snap_hostname, [])
             all_snap_inputs[snap_hostname].append(snap_input)
+            try:  # if present, check if hostnames are the same between polarizations.
+                if snap_to_serial[snap_hostname] != snap_snr[_i]:
+                    warnings.warn(f"snap_hostname {snap_hostname} differs between inputs")
+            except KeyError:  # if not present, add it
+                snap_to_serial[snap_hostname] = snap_snr[_i]
+
     for key, value in all_snap_inputs.items():
         all_snap_inputs[key] = sorted(value)
     return snap_to_ant, ant_to_snap, all_snap_inputs, snap_to_serial

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -100,7 +100,7 @@ class Handling:
         cofa = self.geo.cofa()
         return cofa
 
-    def get_connected_stations(self, at_date, hookup_type=None):
+    def get_connected_stations(self, at_date, snap_name_change=False, hookup_type=None):
         """
         Return a list of class SystemInfo of all of the stations connected at_date.
 
@@ -123,6 +123,8 @@ class Handling:
         ----------
         at_date : str, int
             Date to check for connections.  Anything intelligible by cm_utils.get_astropytime
+        snap_name_change : bool
+            If True, will change SNAP name in correlator input from SNPA000... to heraNodeXSnapY
         hookup_type : str
             Type of hookup to use (current observing system is 'parts_hera').
             If 'None' it will determine which system it thinks it is based on
@@ -159,9 +161,16 @@ class Handling:
                 pe[pol] = hud[key].hookup_type[ppkey]
                 cind = self.sysdef.corr_index[pe[pol]] - 1  # The '- 1' makes it the downstream_part
                 try:
-                    corr[pol] = "{}>{}".format(
-                        hu[cind].downstream_input_port, hu[cind].downstream_part)
-                except IndexError:  # pragma: no cover
+                    snap_part = hu[cind].downstream_part
+                    snap_port = hu[cind].downstream_input_port
+                    node = int(hu[cind + 1].downstream_part[1:])
+                    loc = int(hu[cind + 1].downstream_input_port[3:])
+                    if snap_name_change:
+                        feng = f"heraNode{node}Snap{loc}"
+                    else:
+                        feng = snap_part
+                    corr[pol] = "{}>{}".format(snap_port, feng)
+                except (IndexError, ValueError):  # pragma: no cover
                     corr[pol] = 'None'
                 station_info.timing[pol] = hud[key].timing[ppkey]
             if corr['e'] == 'None' and corr['n'] == 'None':
@@ -212,7 +221,9 @@ class Handling:
         cofa_xyz = uvutils.XYZ_from_LatLonAlt(cofa_loc.lat * np.pi / 180.,
                                               cofa_loc.lon * np.pi / 180.,
                                               cofa_loc.elevation)
-        stations_conn = self.get_connected_stations(at_date='now', hookup_type=hookup_type)
+        stations_conn = self.get_connected_stations(at_date='now',
+                                                    snap_name_change=True,
+                                                    hookup_type=hookup_type)
         stn_arrays = SystemInfo()
         for stn in stations_conn:
             stn_arrays.update_arrays(stn)

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -44,8 +44,7 @@ def test_set_redis_cminfo(mcsession):
     cmitest = {'antenna_numbers': [1], 'antenna_names': ['Fred'],
                'correlator_inputs': [['e0>snapx', 'n2>snapx']],
                'snap_serial_numbers': [['0', '1']]}
-    with pytest.warns(UserWarning, match='snap_hostname snapx differs between inputs'):
-        aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
+    pytest.raises(ValueError, cm_redis_corr.cminfo_redis_snap, cminfo=cmitest)
 
 
 def test_watch_dog(mcsession):

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -37,6 +37,11 @@ def test_set_redis_cminfo(mcsession):
     assert b'heraNode700Snap0' in test_out
     test_out = rsession.hget('testing_corr:map', 'all_snap_inputs')
     assert b'heraNode700Snap0' in test_out
+    cmitest = {'antenna_numbers': [1], 'antenna_names': ['Fred'],
+               'correlator_inputs': [['abc']], 'snap_serial_numbers': ['0']}
+    aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
+    with pytest.warns(UserWarning, match='abc is not an allowed correlator input'):
+        aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
 
 
 def test_watch_dog(mcsession):

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -354,7 +354,7 @@ def test_correlator_info(sys_handle):
     assert len(index) == 1
     index = index[0]
 
-    assert corr_inputs[index] == ('e2>SNPA000700', 'n0>SNPA000700')
+    assert corr_inputs[index] == ('e2>heraNode700Snap0', 'n0>heraNode700Snap0')
 
     assert ([int(name.split('HH')[1]) for name in ant_names]
             == corr_dict['antenna_numbers'])
@@ -378,7 +378,7 @@ def test_correlator_info(sys_handle):
     assert corr_dict['cm_version'] == mc_git_hash
 
     expected_keys = ['antenna_numbers', 'antenna_names', 'antenna_positions',
-                     'correlator_inputs', 'cm_version',
+                     'correlator_inputs', 'cm_version', 'snap_serial_numbers',
                      'cofa_lat', 'cofa_lon', 'cofa_alt']
     assert set(corr_dict.keys()) == set(expected_keys)
 

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -28,23 +28,15 @@ def sys_handle(mcsession):
 def test_set_redis_cminfo(mcsession):
     redishost = TEST_DEFAULT_REDIS_HOST
     rsession = redis.Redis(redishost)
-    rsession.hmset('testing_corr:map', {'snap_host': b'{"SNPB000701":"heraNode700Snap700"}'})
     cm_redis_corr.set_redis_cminfo(redishost=redishost, session=mcsession, testing=True)
     test_out = rsession.hget('testing_corr:map', 'ant_to_snap')
-    assert b'{"host": "SNPA000700", "channel": 0}' in test_out
+    assert b'{"host": "heraNode700Snap0", "channel": 0}' in test_out
     test_out = rsession.hget('testing_cminfo', 'cofa_lat')
     assert b'-30.72' in test_out
     test_out = rsession.hget('testing_corr:map', 'snap_to_ant')
-    assert b'heraNode700Snap700' in test_out
-    snap_info = 'e2>SNPC000008'
-    redis_info = rsession.hget('corr:map', 'not_there')
-    host, adc = cm_redis_corr.snap_part_to_host_input(part=snap_info, redis_info=redis_info)
-    assert host == 'SNPC000008'
-    host, adc = cm_redis_corr.snap_part_to_host_input(part=snap_info, redis_info=None)
-    assert host == 'SNPC000008'
-    assert adc == 1
+    assert b'heraNode700Snap0' in test_out
     test_out = rsession.hget('testing_corr:map', 'all_snap_inputs')
-    assert b'SNPC000702": [0, 1, 2, 3, 4, 5]' in test_out
+    assert b'heraNode700Snap0' in test_out
 
 
 def test_watch_dog(mcsession):

--- a/hera_mc/tests/test_sysutils.py
+++ b/hera_mc/tests/test_sysutils.py
@@ -39,8 +39,12 @@ def test_set_redis_cminfo(mcsession):
     assert b'heraNode700Snap0' in test_out
     cmitest = {'antenna_numbers': [1], 'antenna_names': ['Fred'],
                'correlator_inputs': [['abc']], 'snap_serial_numbers': ['0']}
-    aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
     with pytest.warns(UserWarning, match='abc is not an allowed correlator input'):
+        aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
+    cmitest = {'antenna_numbers': [1], 'antenna_names': ['Fred'],
+               'correlator_inputs': [['e0>snapx', 'n2>snapx']],
+               'snap_serial_numbers': [['0', '1']]}
+    with pytest.warns(UserWarning, match='snap_hostname snapx differs between inputs'):
         aa, bb, cc, dd = cm_redis_corr.cminfo_redis_snap(cmitest)
 
 


### PR DESCRIPTION
This changes the way the snap cm info get passed to the correlator to only use the heraNodeNSnapM format (rather than the SNP serial number).