### PR TITLE
Line up process event api

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+    notify:
+        wait_for_ci: yes

--- a/hera_mc/mc_session.py
+++ b/hera_mc/mc_session.py
@@ -1572,7 +1572,7 @@ class MCSession(Session):
         ----------
         time : astropy Time object
             Time of event.
-        obsid_start : long
+        obsid : long
             Observation obsid for the first obsid (Foreign key into observation).
         task_name : str
             Name of task in pipeline (e.g., OMNICAL)

--- a/scripts/add_rtp_process_event.py
+++ b/scripts/add_rtp_process_event.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
             session.add_rtp_task_multiple_process_event(
                 time=Time.now(),
-                obsid_start=obsid,
+                obsid=obsid,
                 task_name=args.task_name,
                 event=args.event,
             )


### PR DESCRIPTION
The add process event calls in the script where using incorrect keywords when trying to call mc_session methods.