### PR TITLE
Update rtp launch command

### DIFF
--- a/scripts/mc_launch_rtp.py
+++ b/scripts/mc_launch_rtp.py
@@ -194,8 +194,9 @@ for jd in jd_list:
 
     # launch workflow inside of tmux
     cmd = (
-        "source /home/obs/anaconda/bin/deactivate; "
-        f"source /home/obs/anaconda/bin/activate {args.conda_env}; "
+        "source /home/obs/.bashrc; "
+        "conda deactivate; "
+        f"conda activate {args.conda_env}; "
         f"makeflow -T slurm {mf_filename}; /bin/bash -l"
     )
     session_name = f"rtp_{jd}"


### PR DESCRIPTION
Changes the tmux launching command to explicitly source obs's bashrc. 
this allows us to just use conda (de)-activate calls.

changed the default shell to /bin/bash in .tmux.conf file on site.
