### PR TITLE
Launch more RTP jobs

### DIFF
--- a/scripts/mc_launch_rtp.py
+++ b/scripts/mc_launch_rtp.py
@@ -197,7 +197,7 @@ for jd in jd_list:
         "source /home/obs/.bashrc; "
         "conda deactivate; "
         f"conda activate {args.conda_env}; "
-        f"makeflow -T slurm {mf_filename}; /bin/bash -l"
+        f"makeflow -T slurm {mf_filename} -J 100; /bin/bash -l"
     )
     session_name = f"rtp_{jd}"
     tmux_cmd = ["tmux", "new-session", "-d", "-s", session_name, cmd]


### PR DESCRIPTION
This is a quick PR to increase the number of jobs that RTP runs from the default (30) to 100.