### PR TITLE
Modify installation instructions to match reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ database to the new schema.
     - `RTP` conda environment
   - hera-corr-head machine (note: username is `hera`, non-standard pw)
     - `hera` conda environment
-  - pot1 machine
-    - `HERA` conda environment
   - pot6 machine
     - `HERA` conda environment
   Note: other machines share the home drive of qmaster, so no need to install on those.


### PR DESCRIPTION
On a recent site trip, pot1 was changed to use the netboot like most of the other pot machines. This means that it's no longer necessary to update the environment on a schema change (as it's updated with qmaster).