### PR TITLE
Update session handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [3.0.0] - 2022-04-25
+## [3.0.0] - 2022-05-25
 
 ### Added
 - Added `cm_active.get_active` as a courtesy function to return a single ActiveData

--- a/hera_mc/cm_active.py
+++ b/hera_mc/cm_active.py
@@ -38,7 +38,7 @@ def get_active(
     active : ActiveData object
         ActiveData objects with loading parameters as specified.
     """
-    with mc.MCSessionWrapper(None, test=testing) as session:
+    with mc.MCSessionWrapper(None, testing=testing) as session:
         active = ActiveData(
             session, at_date=at_date, at_time=at_time, float_format=float_format
         )

--- a/hera_mc/cm_active.py
+++ b/hera_mc/cm_active.py
@@ -38,11 +38,7 @@ def get_active(
     active : ActiveData object
         ActiveData objects with loading parameters as specified.
     """
-    if testing:
-        db = mc.connect_to_mc_testing_db()
-    else:  # pragma: no cover
-        db = mc.connect_to_mc_db(None)
-    with db.sessionmaker() as session:
+    with mc.MCSessionWrapper(None, test=testing) as session:
         active = ActiveData(
             session, at_date=at_date, at_time=at_time, float_format=float_format
         )

--- a/hera_mc/cm_active.py
+++ b/hera_mc/cm_active.py
@@ -38,9 +38,9 @@ def get_active(
     active : ActiveData object
         ActiveData objects with loading parameters as specified.
     """
-    with mc.MCSessionWrapper(None, testing=testing) as session:
+    with mc.MCSessionWrapper(session=None, testing=testing) as session:
         active = ActiveData(
-            session, at_date=at_date, at_time=at_time, float_format=float_format
+            session=session, at_date=at_date, at_time=at_time, float_format=float_format
         )
         for param in loading:
             getattr(active, f"load_{param}")()

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -65,7 +65,7 @@ def get_hookup(
         Hookup dossier dictionary as defined in cm_dossier
 
     """
-    with mc.MCSessionWrapper(None, testing=testing) as session:
+    with mc.MCSessionWrapper(session=None, testing=testing) as session:
         hookup = Hookup(session)
         return hookup.get_hookup_from_db(
             hpn=hpn,

--- a/hera_mc/cm_hookup.py
+++ b/hera_mc/cm_hookup.py
@@ -65,11 +65,7 @@ def get_hookup(
         Hookup dossier dictionary as defined in cm_dossier
 
     """
-    if testing:
-        db = mc.connect_to_mc_testing_db()
-    else:  # pragma: no cover
-        db = mc.connect_to_mc_db(None)
-    with db.sessionmaker() as session:
+    with mc.MCSessionWrapper(None, testing=testing) as session:
         hookup = Hookup(session)
         return hookup.get_hookup_from_db(
             hpn=hpn,

--- a/hera_mc/cm_partconnect.py
+++ b/hera_mc/cm_partconnect.py
@@ -92,7 +92,7 @@ def update_part_rosetta(
     if date2 is not None:
         date2 = int(cm_utils.get_astropytime(date2, date2time, date2float_format).gps)
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         old_rose = None
         ctr = 0
         for trial in session.query(PartRosetta).filter(
@@ -212,7 +212,7 @@ def stop_existing_parts(session, part_list, at_date, allow_override=False):
     stop_at = int(at_date.gps)
     data = []
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for hpnr in part_list:
             existing = (
                 session.query(Parts)
@@ -266,7 +266,7 @@ def add_new_parts(session, part_list, at_date, allow_restart=False):
     start_at = int(at_date.gps)
     data = []
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for hpnr in part_list:
             existing = (
                 session.query(Parts)
@@ -346,7 +346,7 @@ def update_part(session=None, data=None):
     if data_dict is None:
         return False
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for dkey, dval in data_dict.items():
             hpn_to_change = dval[0][0]
             rev_to_change = dval[0][1]
@@ -449,7 +449,7 @@ def get_part_revisions(hpn, session=None):
 
     uhpn = hpn.upper()
     revisions = {}
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for parts_rec in session.query(Parts).filter(func.upper(Parts.hpn) == uhpn):
             parts_rec.gps2Time()
             revisions[parts_rec.hpn_rev] = {}
@@ -562,7 +562,7 @@ def update_apriori_antenna(
     antenna = antenna.upper()
     last_one = 1000
     old_apa = None
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for trial in session.query(AprioriAntenna).filter(
             func.upper(AprioriAntenna.antenna) == antenna
         ):
@@ -659,7 +659,7 @@ def add_part_info(
 
         warnings.warn("No action taken. Comment is empty.")
         return
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         pi = PartInfo()
         pi.hpn = hpn
         pi.hpn_rev = rev
@@ -882,7 +882,7 @@ def stop_existing_connections_to_part(session, handling, conn_list, at_date):
                     stop_at,
                 ]
                 data.append(stopping)
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         update_connection(session, data, False)
 
 
@@ -914,7 +914,7 @@ def stop_connections(session, conn_list, at_date):
         this_one.append("stop_gpstime")
         this_one.append(stop_at)
         data.append(this_one)
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         update_connection(session, data, False)
 
 
@@ -1043,7 +1043,7 @@ def add_new_connections(session, cobj, conn_list, at_date):
                 cobj.start_gpstime,
             ]
         )
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         update_connection(session, data, True)
 
 
@@ -1074,7 +1074,7 @@ def update_connection(session=None, data=None, add_new_connection=False):
     if data_dict is None:
         print("Error: invalid update")
         return False
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for dkey in data_dict.keys():
             upcn_to_change = data_dict[dkey][0][0]
             urev_to_change = data_dict[dkey][0][1]

--- a/hera_mc/cm_partconnect.py
+++ b/hera_mc/cm_partconnect.py
@@ -1134,11 +1134,7 @@ def update_connection(session=None, data=None, add_new_connection=False):
                 connection = None
             if connection:
                 for d in data_dict[dkey]:
-                    try:
-                        setattr(connection, d[7], d[8])
-                    except AttributeError:
-                        print(dkey, "does not exist as a field")
-                        continue
+                    setattr(connection, d[7], d[8])
                 session.add(connection)
         cm_utils.log("cm_partconn connection update", data_dict=data_dict)
 

--- a/hera_mc/cm_partconnect.py
+++ b/hera_mc/cm_partconnect.py
@@ -1107,15 +1107,19 @@ def update_connection(session=None, data=None, add_new_connection=False):
                     )
                 else:
                     print(
-                        "Error:",
-                        dkey,
-                        "does not exist and add_new_connection is " "not enabled.",
+                        "Warning: no {} and add_new_connection isn't enabled.".format(
+                            dkey
+                        )
                     )
-                    connection = None
+                    return False
             elif num_conn == 1:
                 if add_new_connection:
-                    print("Error:", dkey, "exists and and_new_connection is enabled")
-                    connection = None
+                    print(
+                        "Warning: {} exists and and_new_connection is enabled".format(
+                            dkey
+                        )
+                    )
+                    return False
                 else:
                     connection = conn_rec.first()
             else:  # pragma: no cover

--- a/hera_mc/cm_redis_corr.py
+++ b/hera_mc/cm_redis_corr.py
@@ -96,7 +96,7 @@ def set_redis_cminfo(
     rsession = redis.Redis(connection_pool=redis_pool)
 
     # Write cminfo content into redis (cminfo)
-    with mc.MCSessionWrapper(session, testing=testing) as session:
+    with mc.MCSessionWrapper(session=session, testing=testing) as session:
         h = cm_sysutils.Handling(session=session)
         cminfo = h.get_cminfo_correlator()
 

--- a/hera_mc/cm_revisions.py
+++ b/hera_mc/cm_revisions.py
@@ -48,7 +48,7 @@ def get_revisions_of_type(
     """
     rq = rev_type.upper()
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         if rq.startswith("LAST"):
             revisions = get_last_revision(hpn, session)
         elif rq.startswith("ACTIVE"):
@@ -203,7 +203,7 @@ def get_active_revision(hpn, at_date, at_time=None, float_format=None, session=N
         (hpn, rev, rev_query, started, ended, [hukey], [pkey])
 
     """
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         revisions = cm_partconnect.get_part_revisions(hpn, session)
         return_active = []
         if len(revisions.keys()) > 0:

--- a/hera_mc/cm_sysutils.py
+++ b/hera_mc/cm_sysutils.py
@@ -566,7 +566,7 @@ def node_antennas(source="file", session=None):
                     prefix = "HH"
                 ants_per_node[node_hpn].append("{}{}".format(prefix, ant))
     else:
-        with mc.MCSessionWrapper(session) as session:
+        with mc.MCSessionWrapper(session=session) as session:
             if isinstance(source, str) and source.lower().startswith("h"):
                 source = cm_hookup.Hookup(session)
             hu_dict = source.get_hookup(
@@ -632,7 +632,7 @@ def which_node(ant_num, session=None):
     dict
         Contains antenna and node
     """
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         na_from_file = node_antennas("file", session=session)
         na_from_hookup = node_antennas("hookup", session=session)
     ant_num = cm_utils.listify(ant_num)
@@ -707,7 +707,7 @@ def node_info(node_num="active", session=None):
     dict
         Contains node and node component information
     """
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         hu = cm_hookup.Hookup(session)
         na_from_file = node_antennas("file", session=session)
         na_from_hookup = node_antennas(hu, session=session)

--- a/hera_mc/cm_transfer.py
+++ b/hera_mc/cm_transfer.py
@@ -314,7 +314,7 @@ def _initialization(
     if cm_csv_path is None:
         cm_csv_path = mc.get_cm_csv_path(mc_config_file=None, testing=testing)
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session, testing=testing) as session:
         if not db_validation(maindb, session):
             print("cm_init not allowed.")
             return False

--- a/hera_mc/cm_transfer.py
+++ b/hera_mc/cm_transfer.py
@@ -106,7 +106,7 @@ def package_db_to_csv(session=None, tables="all"):
         "copy, commit and log the change."
     )
     print("    Note:  this works via the hera_cm_db_updates repo.")
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         files_written = []
         for table in tables_to_write:
             data_filename = data_prefix + table + ".csv"
@@ -142,7 +142,7 @@ def pack_n_go(session, cm_csv_path):  # pragma: no cover
     cm_git_hash = cm_utils.get_cm_repo_git_hash(cm_csv_path=cm_csv_path)
 
     # add this cm git hash to cm_version table
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         session.add(CMVersion.create(Time.now(), cm_git_hash))
 
 
@@ -311,7 +311,7 @@ def _initialization(
         Success, True or False
 
     """
-    wrapper = mc.MCSessionWrapper(session, testing=testing)
+    wrapper = mc.MCSessionWrapper(session=session, testing=testing)
     if cm_csv_path is None:
         cm_csv_path = mc.get_cm_csv_path(mc_config_file=None, testing=testing)
 

--- a/hera_mc/geo_handling.py
+++ b/hera_mc/geo_handling.py
@@ -21,11 +21,7 @@ from .data import DATA_PATH
 
 def cofa(testing=False):
     """Return location class of current COFA."""
-    if testing:
-        db = mc.connect_to_mc_testing_db()
-    else:  # pragma: no cover
-        db = mc.connect_to_mc_db(None)
-    with db.sessionmaker() as session:
+    with mc.MCSessionWrapper(None, testing=testing) as session:
         h = Handling(session)
         located = h.cofa()
     return located
@@ -61,11 +57,8 @@ def get_location(
 
     """
     query_date = cm_utils.get_astropytime(query_date, query_time, float_format)
-    if testing:
-        db = mc.connect_to_mc_testing_db()
-    else:  # pragma: no cover
-        db = mc.connect_to_mc_db(None)
-    with db.sessionmaker() as session:
+
+    with mc.MCSessionWrapper(None, testing=testing) as session:
         h = Handling(session)
         located = h.get_location(location_names, query_date)
     return located

--- a/hera_mc/geo_handling.py
+++ b/hera_mc/geo_handling.py
@@ -21,7 +21,7 @@ from .data import DATA_PATH
 
 def cofa(testing=False):
     """Return location class of current COFA."""
-    with mc.MCSessionWrapper(None, testing=testing) as session:
+    with mc.MCSessionWrapper(session=None, testing=testing) as session:
         h = Handling(session)
         located = h.cofa()
     return located
@@ -58,7 +58,7 @@ def get_location(
     """
     query_date = cm_utils.get_astropytime(query_date, query_time, float_format)
 
-    with mc.MCSessionWrapper(None, testing=testing) as session:
+    with mc.MCSessionWrapper(session=None, testing=testing) as session:
         h = Handling(session)
         located = h.get_location(location_names, query_date)
     return located

--- a/hera_mc/geo_location.py
+++ b/hera_mc/geo_location.py
@@ -139,7 +139,7 @@ def update(session=None, data=None, add_new_geo=False):
         print("No update - doing nothing.")
         return False
 
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         for station_name in data_dict.keys():
             geo_rec = session.query(GeoLocation).filter(
                 func.upper(GeoLocation.station_name) == station_name.upper()

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -101,9 +101,9 @@ class MCSessionWrapper:
     Parameters
     ----------
     session : object or None
-        Supplied session, or None.
+        Supplied session, or None.  For some tests is a str
     testing : bool
-        Flag to have new sessions be on testing database.
+        Flag to have new session be on testing database.
 
     """
 
@@ -125,6 +125,8 @@ class MCSessionWrapper:
 
     def __exit__(self, exception_type, exception_value, traceback):
         """Exit the session, rollback if there's an error otherwise commit."""
+        if isinstance(self.session, str):  # Some tests need this.
+            return None
         if exception_type is not None:
             self.session.rollback()  # exception raised
         else:
@@ -134,6 +136,8 @@ class MCSessionWrapper:
 
     def wrapup(self, updated=False):
         """Close out the session in a non-context manner."""
+        if isinstance(self.session, str):  # Some tests need this.
+            return None
         if updated:
             self.session.commit()
         if self.close_when_done:

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -101,7 +101,7 @@ class MCSessionWrapper:
     Parameters
     ----------
     session : object or None
-        Supplied session, or None.  For some tests is a str
+        Supplied session, or None.  For some tests it is a str
     testing : bool
         Flag to have new session be on testing database.
 

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -129,7 +129,7 @@ class MCSessionWrapper:
             self.session.rollback()  # exception raised
         else:
             self.session.commit()  # success
-        self.exit(updated=False)
+        self.wrapup(updated=False)
         return False  # propagate exception if any occurred
 
     def wrapup(self, updated=False):

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -108,7 +108,6 @@ class MCSessionWrapper:
     """
 
     def __init__(self, session=None, testing=False):
-        self.is_context = False
         if session is None:
             if testing:
                 db = connect_to_mc_testing_db()
@@ -122,7 +121,6 @@ class MCSessionWrapper:
 
     def __enter__(self):
         """Enter the session."""
-        self.is_context = True
         return self.session
 
     def __exit__(self, exception_type, exception_value, traceback):
@@ -139,7 +137,7 @@ class MCSessionWrapper:
         """Close out the session in a non-context manner."""
         if not isinstance(self.session, MCSession):
             return None
-        if updated and not self.is_context:
+        if updated:
             self.session.commit()
         if self.close_when_done:
             self.session.close()

--- a/hera_mc/tests/test_cm_transfer.py
+++ b/hera_mc/tests/test_cm_transfer.py
@@ -70,6 +70,15 @@ def test_initialization():
 def test_check_if_main(mcsession):
     result = cm_transfer.check_if_main(mcsession)
     assert not result
+    with mc.MCSessionWrapper("testing_not_main") as session:
+        result = cm_transfer.check_if_main(session)
+    assert not result
+    wrapper = mc.MCSessionWrapper("testing_main")
+    result = cm_transfer.check_if_main(wrapper.session)
+    wrapper.wrapup()
+    assert result
+    wrapper = mc.MCSessionWrapper(mcsession)
+    wrapper.wrapup(updated=True)
 
 
 def test_cm_table_info():

--- a/hera_mc/tests/test_cm_transfer.py
+++ b/hera_mc/tests/test_cm_transfer.py
@@ -70,14 +70,14 @@ def test_initialization():
 def test_check_if_main(mcsession):
     result = cm_transfer.check_if_main(mcsession)
     assert not result
-    with mc.MCSessionWrapper("testing_not_main") as session:
+    with mc.MCSessionWrapper(session="testing_not_main") as session:
         result = cm_transfer.check_if_main(session)
     assert not result
-    wrapper = mc.MCSessionWrapper("testing_main")
+    wrapper = mc.MCSessionWrapper(session="testing_main")
     result = cm_transfer.check_if_main(wrapper.session)
     wrapper.wrapup()
     assert result
-    wrapper = mc.MCSessionWrapper(mcsession)
+    wrapper = mc.MCSessionWrapper(session=mcsession)
     wrapper.wrapup(updated=True)
 
 

--- a/hera_mc/tests/test_connections.py
+++ b/hera_mc/tests/test_connections.py
@@ -137,6 +137,11 @@ def test_update_new(conns, capsys):
     )
     assert next_conn.upstream_part == "new_test_part_up"
 
+    conn_list = [["HH701", "A", "ground"]]
+    cm_partconnect.update_connection(conns.test_session, data, add_new_connection=True)
+    captured = capsys.readouterr()
+    assert captured.out.strip().startswith("Warning: no new_test_part_up:")
+
 
 def test_get_null_connection():
     nc = cm_partconnect.get_null_connection()

--- a/hera_mc/tests/test_connections.py
+++ b/hera_mc/tests/test_connections.py
@@ -112,6 +112,10 @@ def test_update_new(conns, capsys):
         [u, r, d, r, a, b, g, "downstream_input_port", b],
         [u, r, d, r, a, b, g, "start_gpstime", g],
     ]
+    result = cm_partconnect.update_connection(
+        conns.test_session, data, add_new_connection=False
+    )
+    assert not result
     cm_partconnect.update_connection(conns.test_session, data, add_new_connection=True)
     located = conns.cm_handle.get_dossier([u], r, "now", exact_match=True)
     prkey = list(located.keys())[0]
@@ -147,6 +151,10 @@ def test_stop_existing_connections_to_part(conns, capsys):
     )
     captured = capsys.readouterr()
     assert captured.out.strip().startswith("Stopping connection")
+    result = cm_partconnect.update_connection(
+        conns.test_session, conn_list, update_new_connection=True
+    )
+    assert not result
 
 
 def test_various_connection(capsys):

--- a/hera_mc/tests/test_connections.py
+++ b/hera_mc/tests/test_connections.py
@@ -152,9 +152,9 @@ def test_stop_existing_connections_to_part(conns, capsys):
     captured = capsys.readouterr()
     assert captured.out.strip().startswith("Stopping connection")
     result = cm_partconnect.update_connection(
-        conns.test_session, conn_list, update_new_connection=True
+        conns.test_session, conn_list, add_new_connection=True
     )
-    assert not result
+    assert result
 
 
 def test_various_connection(capsys):

--- a/hera_mc/tests/test_geo_location.py
+++ b/hera_mc/tests/test_geo_location.py
@@ -65,6 +65,18 @@ def test_update_new(mcsession, geo_handle):
     geo_location.update(mcsession, data, add_new_geo=True)
     located = geo_handle.get_location([nte], "now")
     assert located[0].station_type_name == "herahex"
+    nte = "HH_another_new_test_element"
+    data = [
+        [nte, "station_name", nte],
+        [nte, "station_type_name", "herahex"],
+        [nte, "datum", "WGS84"],
+        [nte, "tile", "34J"],
+        [nte, "northing", 6600000.0],
+        [nte, "easting", 541000.0],
+        [nte, "elevation", 1050.0],
+        [nte, "created_gpstime", 1172530000],
+    ]
+    pytest.raises(ValueError, geo_location.update, mcsession, data, add_new_geo=False)
 
 
 def test_update_update(mcsession, geo_handle):
@@ -72,6 +84,7 @@ def test_update_update(mcsession, geo_handle):
     geo_location.update(mcsession, data, add_new_geo=False)
     located = geo_handle.get_location(["HH704"], "now")
     assert located[0].elevation == 1100.0
+    pytest.raises(ValueError, geo_location.update, mcsession, data, add_new_geo=True)
 
 
 def test_random(geo_handle, capsys):

--- a/hera_mc/watch_dog.py
+++ b/hera_mc/watch_dog.py
@@ -185,7 +185,7 @@ def node_temperature(
         use_last = False
         at_date = cm_utils.get_astropytime(at_date, at_time, float_format)
     gps_time = at_date.gps
-    with mc.MCSessionWrapper(session) as session:
+    with mc.MCSessionWrapper(session=session) as session:
         active_parts = cm_active.ActiveData(session=session)
         active_parts.load_parts(at_date)
         active_nodes = sorted(


### PR DESCRIPTION
All calls for an external session are now handled through MCSessionWrapper

## Description
Database sessions from within configuration management are handled by either passing a session or by passing None, whereby a new session was started.  This led to a cumbersome set of statements and a `close_session_when_done` flag.  This PR sets up a new session wrapper to handle all of that in a much cleaner fashion.

## Motivation and Context
The cleans up the code and also makes it much safer in terms of closing sessions appropriate.  It also incorporates the testing flag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [ ] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other

## Checklist:
Other:
- [x] My code follows the code style of this project.
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [ ] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [ ] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
