### PR TITLE
add a catcher variable to wrapper session close

### DIFF
--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -140,7 +140,7 @@ class MCSessionWrapper:
         if updated:
             self.session.commit()
         if self.close_when_done:
-            _catcher = self.session.close()  # noqa - need to catch the return
+            _ = self.session.close()
 
 
 def get_mc_argument_parser():

--- a/hera_mc/mc.py
+++ b/hera_mc/mc.py
@@ -140,7 +140,7 @@ class MCSessionWrapper:
         if updated:
             self.session.commit()
         if self.close_when_done:
-            self.session.close()
+            _catcher = self.session.close()  # noqa - need to catch the return
 
 
 def get_mc_argument_parser():


### PR DESCRIPTION
## Description
When the session wrapper closed, the return was being printed to my screen, which caused extraneous print statements.  I added an underscore to catch the return of the module to remove the extraneous print statement to my screen.

## Motivation and Context
Gets rid of annoying and non-illuminating printed lines.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [ ] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other

Other:
- [x ] My code follows the code style of this project.
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [x] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [x] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
