### PR TITLE
update rtp process record to be compatible with scm

### DIFF
--- a/scripts/add_rtp_process_record.py
+++ b/scripts/add_rtp_process_record.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
             rtp_git_version=version_info["hera_opm"]["tag"],
             rtp_git_hash=version_info["hera_opm"]["hash"],
             hera_qm_git_version=version_info["hera_qm"]["tag"],
-            hera_qm_git_hash=version_info["herq_qm"]["hash"],
+            hera_qm_git_hash=version_info["hera_qm"]["hash"],
             hera_cal_git_version=version_info["hera_cal"]["tag"],
             hera_cal_git_hash=version_info["hera_cal"]["hash"],
             pyuvdata_git_version=version_info["pyuvdata"]["tag"],


### PR DESCRIPTION
@jsdillon noticed that RTP is failing now that we switched all the repos to `setuptools_scm`. I updated the `add_rtp_process_record` to treat everything like how pyuvdata was parsed before.