### PR TITLE
Add the SNAP feng_init status to the monitoring daemon

### DIFF
--- a/scripts/mc_monitor_correlator.py
+++ b/scripts/mc_monitor_correlator.py
@@ -30,6 +30,7 @@ commands_to_run = [
     "add_correlator_component_event_time_from_redis",
     "add_correlator_config_from_corrcm",
     "add_snap_status_from_corrcm",
+    "add_snap_feng_init_status_from_redis",
     "add_corr_snap_versions_from_corrcm",
     "add_antenna_status_from_corrcm",
     "add_autocorrelations_from_redis",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This should have been included in #616, it makes the daemon actually get the `snap_feng_init_status` out of redis and put it in M&C.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [ ] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [x] Other

## Checklist:
<!--- You shoud remove the checklists that don't apply to your change type(s) -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Other:
- [x] My code follows the code style of this project.
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [x] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [ ] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
