### PR TITLE
Mini snap make folders

### DIFF
--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -299,7 +299,7 @@ while True:
 
                 # make the fold for the JD if it does not exist
                 folder = Path(args.outdir) / folder_name
-                folder.mkdir(exists_ok=True)
+                folder.mkdir(exist_ok=True)
 
                 fname = folder / f"zen.{date:.6f}.snap_autos.uvh5"
                 logger.info(f"Writing output file {fname}.")

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -204,13 +204,15 @@ while True:
                     # and when we started this inner loop
 
                     downtime = (
-                        Time.now()
-                        - min(
-                            inner_loop_restart,
-                            last_time,
-                            last_loop_completion,
+                        (
+                            Time.now()
+                            - np.asarray(
+                                [inner_loop_restart, last_time, last_loop_completion]
+                            )
                         )
-                    ).to_value("s")
+                        .min()
+                        .to_value("s")
+                    )
                     if len(time_array) > 0:
                         file_len = TimeDelta(
                             time_array[-1] - time_array[0], format="jd"

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -299,7 +299,7 @@ while True:
 
                 folder_name = f"{int(np.floor(date)):d}"
 
-                # make the fold for the JD if it does not exist
+                # make the folder for the JD if it does not exist
                 folder = Path(args.outdir) / folder_name
                 folder.mkdir(exist_ok=True)
 

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -128,7 +128,7 @@ while True:
 
                 inner_loop_restart = Time.now()
 
-                while downtime < args.max_downtime and file_len < args.max_file_len:
+                while (downtime < args.max_downtime) and (file_len < args.max_file_len):
                     time.sleep(0.01)
                     # get integrations from HeraCorrCM.get_snaprf_status()
                     # compare to the last time for each snap

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -295,7 +295,7 @@ while True:
 
                 date = Time.now().jd
 
-                folder_name = f"{int(date.floor()):d}"
+                folder_name = f"{int(np.floor(date)):d}"
 
                 # make the fold for the JD if it does not exist
                 folder = Path(args.outdir) / folder_name

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -278,9 +278,18 @@ while True:
                 uvd.extra_keywords["snap_to_ant_mapping"] = json.dumps(
                     snap_to_ant_mapping
                 )
-                fname = f"zen.{Time.now().jd:.6f}.snap_autos.uvh5"
+
+                date = Time.now().jd
+
+                folder_name = f"{int(date.floor()):d}"
+
+                # make the fold for the JD if it does not exist
+                folder = Path(args.outdir) / folder_name
+                folder.mkdir(exists_ok=True)
+
+                fname = folder / f"zen.{date:.6f}.snap_autos.uvh5"
                 logger.info(f"Writing output file {fname}.")
-                uvd.write_uvh5(Path(args.outdir) / fname)
+                uvd.write_uvh5(fname)
 
                 last_loop_completion = Time.now()
 


### PR DESCRIPTION
Organizes the mini-snap catcher to write data to folders based on the JD.

Tried to sure up some logic to reduce the amount of logger warnings about data timeouts.

On site verified that data is written to the expected folders but haven't verified the logger is any less talkative yet (currently taking data at time of writing).