### PR TITLE
Fix how prefix directory is handled when adding files to RTP

### DIFF
--- a/scripts/mc_rtp_launch_record.py
+++ b/scripts/mc_rtp_launch_record.py
@@ -46,9 +46,10 @@ for uvfile in args.files:
     # get appropriate filename and prefix information
     filename = os.path.basename(uvfile)
     hostname = socket.gethostname()
-    if "hera-sn1" in hostname:
+    cwd = os.getcwd()
+    if "hera-sn1" in hostname or cwd.startswith("/mnt/sn1"):
         prefix = os.path.join("/mnt/sn1", f"{int_jd:d}")
-    elif "hera-sn2" in hostname:
+    elif "hera-sn2" in hostname or cwd.startswith("/mnt/sn2"):
         prefix = os.path.join("/mnt/sn2", f"{int_jd:d}")
     else:
         # default


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When adding data files to the M&C tables for RTP, we need to know where to find these files on disk. In particular, there are in principle two different storage nodes for data to end up. Previously we were always running this script from the storage nodes. Now, we are calling this from the RTP execution hosts as part of the file conversion process, so the `hostname` command does not give the result it did previously. This change has been deployed to site and seems to be working.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a bug observed onsite where the prefix was recorded as `unknown`, which then meant that RTP failed to launch correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [ ] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other

## Checklist:
<!--- You shoud remove the checklists that don't apply to your change type(s) -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [x] My code follows the code style of this project.
- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [x] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [ ] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
