### PR TITLE
Better time filtering to allow for getting the most recent table entry as of a time in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ commanded signal source (one of "antenna", "load", "noise", "digital_same_seed",
 had an event related to normal observing (f-engine sync, x-engine integration start,
 catcher start, stop or stop identified via a timeout).
 
+
+### Changed
+- The logic for time filtering in real time getter methods in mc_session to support
+getting the most recent table entries at some point in the past (the last value before
+the time of interest)
+
 ### Removed
 - The following table bindings were removed (but the tables will not be deleted on site):
 `correlator_control_state`, `correlator_control_command`,`correlator_take_data_arguments`,

--- a/hera_mc/tests/test_correlator.py
+++ b/hera_mc/tests/test_correlator.py
@@ -349,6 +349,20 @@ def test_add_array_signal_source(mcsession):
 
     assert source_result[1].isclose(source_expected2)
 
+    source_result_mr_start = mcsession.get_array_signal_source(
+        most_recent=True, starttime=t1 + TimeDelta(3.0, format="sec")
+    )
+    source_result_start = mcsession.get_array_signal_source(
+        starttime=t1 + TimeDelta(3.0, format="sec")
+    )
+
+    assert len(source_result_mr_start) == 1
+    assert len(source_result_start) == 1
+    assert not source_result_mr_start[0].isclose(source_result_start[0])
+
+    assert source_result_mr_start[0].isclose(source_expected)
+    assert source_result_start[0].isclose(source_expected2)
+
     # this tests different column types not matching:
     source_expected2 = corr.ArraySignalSource(time=t2.gps, source="digital_same_seed")
     assert not source_result[1].isclose(source_expected2)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently it is easy to get the next entry after a point in time or the most recent entry as of the current time, but it is hard to get the last entry before a point in time (the most recent as of that time). This PR improves the time filter logic that nearly all the real time db getter methods use to enable getting the most recent entry in a table as of a time in the past.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
This came up recently as an issue in the daily notebooks. I put in a work around, but this will simplify the logic there and for other users.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [x] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other

## Checklist:
<!--- You shoud remove the checklists that don't apply to your change type(s) -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

New feature without schema change checklist:
- [x] My code follows the code style of this project.
- [x] I have added or updated the docstrings associated with my feature using the [numpy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [x] I have added tests to cover my new feature.
- [ ] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [x] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
