### PR TITLE
properly convert strings to ints from redis for file_eod table

### DIFF
--- a/hera_mc/correlator.py
+++ b/hera_mc/correlator.py
@@ -754,11 +754,13 @@ def _get_correlator_file_eod_status_from_redis(redishost=DEFAULT_REDIS_ADDRESS):
     rsession = redis.Redis(connection_pool=redis_pool, charset="utf-8")
 
     file_eod_dict = rsession.hgetall("corr:files:jds")
-
+    new_dict = {}
+    for key, val in file_eod_dict.items():
+        new_dict[int(key)] = int(val)
     # keys are:
     #  - jd
     #  - status value
-    return file_eod_dict
+    return new_dict
 
 
 class CorrelatorConfigFile(MCDeclarativeBase):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ addopts = --ignore=scripts
 # B905 is for using zip without the `strict` argument, which was introduced in
 # python 3.10. We should probably add this check (remove it from the ignore) when we
 # require 3.10.
-ignore = W503, E203, B905
+ignore = W503, E203, B905, B907
 per-file-ignores =
     alembic/*.py: B,C,E,W,T4,B9,F,D
     scripts/*.py: D


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug in getting the correlator file eod info from redis: the jd and status values are strings and need to be converted to ints.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->
Fixes a bug in #644 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Schema change (any change to the SQL tables)
- [ ] New feature without schema change (non-breaking change which adds functionality)
- [ ] Change associated with a change in redis structure
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Version change
- [ ] Build or continuous integration change
- [ ] Other

## Checklist:
<!--- You shoud remove the checklists that don't apply to your change type(s) -->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

Bug fix checklist:
- [x] My code follows the code style of this project.
- [x] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] I understand the updates required onsite (detailed in the readme) and I will make those
changes when this is merged.
- [ ] Unit tests pass **on site** (This is a critical check, CI can differ from site).
- [ ] I have updated the [CHANGELOG](https://github.com/HERA-Team/hera_mc/blob/main/CHANGELOG.md).
