### PR TITLE
Add a backstop to file conversion before launching RTP

### DIFF
--- a/scripts/mc_launch_rtp_daemon.py
+++ b/scripts/mc_launch_rtp_daemon.py
@@ -141,8 +141,16 @@ if __name__ == "__main__":
             continue
 
         # convert datfiles missing from M&C
-        dirnames = {os.path.dirname(f) for f in filelist}  # should be only one, but this is more robust
-        datfiles = sorted([datfile for dirname in dirnames for datfile in glob.glob(os.path.join(dirname, '*.dat'))])
+        dirnames = {
+            os.path.dirname(f) for f in filelist
+        }  # should be only one, but this is more robust
+        datfiles = sorted(
+            [
+                datfile
+                for dirname in dirnames
+                for datfile in glob.glob(os.path.join(dirname, "*.dat"))
+            ]
+        )
         for datfile in datfiles:
             uvh5_file = datfile.replace(".dat", ".uvh5")
             if not os.path.exists(uvh5_file):
@@ -154,7 +162,7 @@ if __name__ == "__main__":
                         f"Trying to convert {datfile} to {uvh5_file} using {metadata_file}..."
                     )
                     make_uvh5_file(uvh5_file, metadata_file, datfile)
-                    print('    Succeeded.\n')
+                    print("    Succeeded.\n")
                     filelist.append(uvh5_file)
                 except Exception as exc:
                     print(exc)

--- a/scripts/mc_launch_rtp_daemon.py
+++ b/scripts/mc_launch_rtp_daemon.py
@@ -10,8 +10,8 @@ which to launch an RTP workflow.  For each observation
 included in a launched workflow, the corresponding RTPLaunchRecord is updated.
 """
 
-import os
 import glob
+import os
 import shutil
 import subprocess
 import warnings
@@ -20,9 +20,9 @@ import h5py
 import hera_opm.mf_tools as mt
 import numpy as np
 from astropy.time import Time
+from paper_gpu.file_conversion import make_uvh5_file
 
 from hera_mc import mc
-from paper_gpu.file_conversion import make_uvh5_file
 
 REDISHOST = "redishost"
 JD_KEY = "corr:files:jds"
@@ -142,19 +142,29 @@ if __name__ == "__main__":
 
         # convert datfiles missing from M&C
         dirnames = set(os.path.dirname(f) for f in filelist)
-        datfiles = sorted([datfile for dirname in dirnames for datfile in glob.glob(os.path.join(dirname, '*.dat'))])
+        datfiles = sorted(
+            [
+                datfile
+                for dirname in dirnames
+                for datfile in glob.glob(os.path.join(dirname, "*.dat"))
+            ]
+        )
         for datfile in datfiles:
-            uvh5_file = datfile.replace('.dat', '.uvh5')
+            uvh5_file = datfile.replace(".dat", ".uvh5")
             if not os.path.exists(uvh5_file):
                 try:
-                    metadata_file = datfile.replace('.sum.dat', '.meta.hdf5').replace('.diff.dat', '.meta.hdf5')
-                    print(f'Trying to convert {datfile} to {uvh5_file} using {metadata_file}...')
+                    metadata_file = datfile.replace(".sum.dat", ".meta.hdf5").replace(
+                        ".diff.dat", ".meta.hdf5"
+                    )
+                    print(
+                        f"Trying to convert {datfile} to {uvh5_file} using {metadata_file}..."
+                    )
                     make_uvh5_file(uvh5_file, metadata_file, datfile)
-                    print('    Succeeded.\n')
+                    print("    Succeeded.\n")
                     filelist.append()
                 except Exception as exc:
                     print(exc)
-                    print(f'Failed to convert {datfile} to {uvh5_file}. Moving on...\n')
+                    print(f"Failed to convert {datfile} to {uvh5_file}. Moving on...\n")
         filelist = sorted(filelist)
 
         # scan files if desired
@@ -181,8 +191,8 @@ if __name__ == "__main__":
         # remove converted datfiles if desired. This saves space on /mnt/sn1
         if REMOVE_CONVERTED_DATFILES:
             for file in filelist:
-                if os.path.exists(file.replace('.uvh5', '.dat')):
-                    os.remove(file.replace('.uvh5', '.dat'))
+                if os.path.exists(file.replace(".uvh5", ".dat")):
+                    os.remove(file.replace(".uvh5", ".dat"))
 
         # go to working directory
         os.chdir(WORKING_DIRECTORY)

--- a/scripts/mc_launch_rtp_daemon.py
+++ b/scripts/mc_launch_rtp_daemon.py
@@ -141,14 +141,8 @@ if __name__ == "__main__":
             continue
 
         # convert datfiles missing from M&C
-        dirnames = set(os.path.dirname(f) for f in filelist)
-        datfiles = sorted(
-            [
-                datfile
-                for dirname in dirnames
-                for datfile in glob.glob(os.path.join(dirname, "*.dat"))
-            ]
-        )
+        dirnames = {os.path.dirname(f) for f in filelist}  # should be only one, but this is more robust
+        datfiles = sorted([datfile for dirname in dirnames for datfile in glob.glob(os.path.join(dirname, '*.dat'))])
         for datfile in datfiles:
             uvh5_file = datfile.replace(".dat", ".uvh5")
             if not os.path.exists(uvh5_file):
@@ -160,8 +154,8 @@ if __name__ == "__main__":
                         f"Trying to convert {datfile} to {uvh5_file} using {metadata_file}..."
                     )
                     make_uvh5_file(uvh5_file, metadata_file, datfile)
-                    print("    Succeeded.\n")
-                    filelist.append()
+                    print('    Succeeded.\n')
+                    filelist.append(uvh5_file)
                 except Exception as exc:
                     print(exc)
                     print(f"Failed to convert {datfile} to {uvh5_file}. Moving on...\n")
@@ -188,7 +182,7 @@ if __name__ == "__main__":
                     obsid = _obsid_from_time_array(uvd.time_array)
                     obsids.append(obsid)
 
-        # remove converted datfiles if desired. This saves space on /mnt/sn1
+        # remove converted .dat files if desired. This saves space on /mnt/sn1 if RTP gets backed up
         if REMOVE_CONVERTED_DATFILES:
             for file in filelist:
                 if os.path.exists(file.replace(".uvh5", ".dat")):


### PR DESCRIPTION
This PR adds a step in the RTP launch script as a last-ditch backstop for fileconversion. Over the past week, I've noticed a least three different nights where one or a handful of files fail to convert (often the .diff or .sum but not the other). This script finds those unconverted files and tries one last time to convert them before launching RTP. 

This PR also adds deletion of .dat files that have been successfully converted. This is useful for saving space on /mnt/sn1 in the case where RTP gets backed up (since .dat files are roughly double the size of .uvh5 files)