### PR TITLE
change the order metadata is filled in by helper functions

### DIFF
--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -280,17 +280,18 @@ while True:
                     cat_name="unprojected", cat_type="unprojected"
                 )
                 uvd.phase_center_id_array = np.full(uvd.Nblts, cat_id, dtype=int)
+
+                uvd._set_future_array_shapes()
+                uvd.set_lsts_from_time_array()
                 uvd._set_app_coords_helper()
 
                 uvd.set_uvws_from_antenna_positions()
-                uvd.set_lsts_from_time_array()
 
                 uvd.telescope_name = "HERA"
                 uvd.instrument = "HERA"
                 uvd.history = f"Created by {__file__}."
 
                 # lets us not have to spectral windows
-                uvd._set_future_array_shapes()
 
                 uvd.reorder_blts("time", "baseline")
                 uvd.extra_keywords["snap_to_ant_mapping"] = json.dumps(

--- a/scripts/hera_mini_snap_data_catcher.py
+++ b/scripts/hera_mini_snap_data_catcher.py
@@ -12,6 +12,7 @@ import traceback
 from pathlib import Path
 
 import numpy as np
+from astropy import units
 from astropy.time import Time, TimeDelta
 from hera_corr_cm import HeraCorrCM
 from hera_corr_cm.redis_cm import read_cminfo_from_redis, read_maps_from_redis
@@ -212,7 +213,7 @@ while True:
                     )
                     if len(time_array) > 0:
                         file_len = TimeDelta(
-                            time_array[-1] - time_array[0], format="jd"
+                            (time_array[-1] - time_array[0]) * units.day, format="jd"
                         ).to_value("s")
 
                 time_array = np.asarray(time_array)


### PR DESCRIPTION
needed to also change the order some meta-data was generated before and missed it.
definitely works now

```bash
2024-03-19 21:57:41.133 INFO - hera_mini_snap_data_catcher: Starting HERA snap mini data catcher.
2024-03-19 21:57:41.137 INFO - hera_mini_snap_data_catcher: HERA CorrCM Redis connection established.
2024-03-19 21:57:41.143 INFO - hera_mini_snap_data_catcher: Beginning data catching.
WARNING: TimeDeltaMissingUnitWarning: Numerical value without unit or explicit format passed to TimeDelta, assuming days [astropy.time.core]
2024-03-19 21:58:11.809 WARNING - logger: TimeDeltaMissingUnitWarning: Numerical value without unit or explicit format passed to TimeDelta, assuming days
2024-03-19 22:00:14.780 INFO - hera_mini_snap_data_catcher: Writing output file /mnt/sn1/snap_autos/2460389/zen.2460389.416836.snap_autos.uvh5.
key snap_to_ant_mapping in extra_keywords is longer than 8 characters. It will be truncated to 8 if written to uvfits or miriad file formats.
```